### PR TITLE
Textures and texture references perform refcounting

### DIFF
--- a/GameProject/Engine/Rendering/AssetContainers/Material.hpp
+++ b/GameProject/Engine/Rendering/AssetContainers/Material.hpp
@@ -9,6 +9,6 @@ struct MaterialAttributes {
 };
 
 struct Material {
-    std::vector<Texture> textures;
+    std::vector<TextureReference> textures;
     MaterialAttributes attributes;
 };

--- a/GameProject/Engine/Rendering/AssetContainers/Texture.hpp
+++ b/GameProject/Engine/Rendering/AssetContainers/Texture.hpp
@@ -1,17 +1,115 @@
 #pragma once
 
 #include <Engine/Rendering/AssetContainers/AssetResources.hpp>
+#include <atomic>
 #include <d3d11.h>
 
-// Not currently used
-enum TX_TYPE {
-    // Indicates a texture failed to load or has yet to be loaded
-    NO_TEXTURE,
-    DIFFUSE = aiTextureType_DIFFUSE,
-    NORMAL = aiTextureType_NORMALS
+class Texture
+{
+public:
+    Texture()
+        :m_RefCount(0),
+        m_pSRV(nullptr)
+    {}
+
+    Texture(ID3D11ShaderResourceView* pSRV)
+        :m_RefCount(0),
+        m_pSRV(pSRV)
+    {}
+
+    ~Texture()
+    {
+        if (m_pSRV != nullptr) {
+            m_pSRV->Release();
+        }
+    }
+
+    /*  Can't transfer ownership, texture references would end up referencing an old texture object
+        Could implement these in the future, where the functions would copy the texture data,
+        without transferring ownership.*/
+    Texture(const Texture& texture) = delete;
+    void operator=(const Texture& texture) = delete;
+
+    int getRefCount() const
+    {
+        return m_RefCount.load();
+    }
+
+    ID3D11ShaderResourceView* getSRV() const
+    {
+        return m_pSRV;
+    }
+
+    void setSRV(ID3D11ShaderResourceView* pSRV)
+    {
+        m_pSRV = pSRV;
+    }
+
+protected:
+    void increaseRefCount()
+    {
+        m_RefCount += 1;
+    }
+
+    void decreaseRefCount()
+    {
+        m_RefCount -= 1;
+
+        if (m_RefCount == 0 && m_pSRV != nullptr) {
+            m_pSRV->Release();
+            m_pSRV = nullptr;
+        }
+    }
+
+private:
+    friend class TextureReference;
+
+    ID3D11ShaderResourceView* m_pSRV;
+    std::atomic_int m_RefCount;
 };
 
-struct Texture
+class TextureReference
 {
-    ID3D11ShaderResourceView* srv;
+public:
+    TextureReference()
+        :m_pTexture(nullptr)
+    {}
+
+    TextureReference(Texture* pTexture)
+        :m_pTexture(pTexture)
+    {
+        if (pTexture != nullptr) {
+            m_pTexture->increaseRefCount();
+        }
+    }
+
+    ~TextureReference()
+    {
+        if (m_pTexture != nullptr) {
+            m_pTexture->decreaseRefCount();
+        }
+    }
+
+    TextureReference(const TextureReference& textureReference)
+    {
+        m_pTexture = textureReference.m_pTexture;
+
+        if (m_pTexture != nullptr) {
+            m_pTexture->increaseRefCount();
+        }
+    }
+
+    void operator=(const TextureReference& textureReference)
+    {
+        m_pTexture = textureReference.m_pTexture;
+        m_pTexture->increaseRefCount();
+    }
+
+    ID3D11ShaderResourceView* getSRV() const
+    {
+        return m_pTexture->m_pSRV;
+    }
+
+private:
+    Texture* m_pTexture;
 };

--- a/GameProject/Engine/Rendering/AssetLoaders/TextureLoader.hpp
+++ b/GameProject/Engine/Rendering/AssetLoaders/TextureLoader.hpp
@@ -11,12 +11,12 @@ public:
     TextureLoader(SystemSubscriber* sysSubscriber, ID3D11Device* device);
     ~TextureLoader();
 
-    Texture loadTexture(const std::string& filePath);
+    TextureReference loadTexture(const std::string& filePath);
 
     void deleteAllTextures();
 
 private:
-    std::unordered_map<std::string, Texture> textures;
+    std::unordered_map<std::string, Texture*> textures;
 
     ID3D11Device* device;
 };

--- a/GameProject/Engine/Rendering/Renderer.cpp
+++ b/GameProject/Engine/Rendering/Renderer.cpp
@@ -179,7 +179,8 @@ void Renderer::update(float dt)
 
             /* Pixel shader */
             // Diffuse texture
-            context->PSSetShaderResources(0, 1, &model->materials[mesh.materialIndex].textures[0].srv);
+            ID3D11ShaderResourceView* pDiffuseSRV = model->materials[mesh.materialIndex].textures[0].getSRV();
+            context->PSSetShaderResources(0, 1, &pDiffuseSRV);
             context->PSSetSamplers(0, 1, this->aniSampler);
 
             // Material cbuffer

--- a/GameProject/Engine/Rendering/Text/TextRenderer.hpp
+++ b/GameProject/Engine/Rendering/Text/TextRenderer.hpp
@@ -3,6 +3,7 @@
 #define NOMINMAX
 
 #include <Engine/ECS/ComponentHandler.hpp>
+#include <Engine/Rendering/AssetContainers/Texture.hpp>
 #include <Engine/Rendering/ShaderHandler.hpp>
 #include <DirectXMath.h>
 #include <d3d11.h>
@@ -32,7 +33,7 @@ public:
     ~TextRenderer();
 
     // Creates a texture with text rendered onto it
-    ID3D11ShaderResourceView* renderText(const std::string& text, const std::string& font, unsigned int fontPixelHeight);
+    TextureReference renderText(const std::string& text, const std::string& font, unsigned int fontPixelHeight);
 
 private:
     // Loads and maps each character in a string to FreeType glyph data
@@ -50,11 +51,12 @@ private:
     // Convert a bitmap into a bytemap
     void bitmapToBytemap(const FT_Bitmap& bitmap, Bytemap& bytemap);
 
+private:
     ID3D11Device* device;
     ID3D11DeviceContext* context;
 
-    // Maps font names to a mapping of characters to loaded character textures
-    std::map<std::string, std::map<char, ID3D11ShaderResourceView*>> loadedCharacters;
+    // Rendering text results in a texture and a texture reference being created. This is the storage for the textures.
+    std::vector<Texture*> m_Textures;
 
     FT_Library ftLib;
 

--- a/GameProject/Engine/UI/Panel.hpp
+++ b/GameProject/Engine/UI/Panel.hpp
@@ -3,6 +3,7 @@
 #define NOMINMAX
 
 #include <Engine/ECS/ComponentHandler.hpp>
+#include <Engine/Rendering/AssetContainers/Texture.hpp>
 #include <Engine/Utils/IDVector.hpp>
 
 #include <DirectXMath.h>
@@ -41,7 +42,7 @@ struct TextureAttachmentInfo {
 struct TextureAttachment {
     // Position and size are specified as [0, 1], and are relative to the panel's position and size.
     DirectX::XMFLOAT2 position, size;
-    ID3D11ShaderResourceView* texture;
+    TextureReference texture;
 };
 
 struct UIPanel {
@@ -53,7 +54,7 @@ struct UIPanel {
     float highlightFactor;
     DirectX::XMFLOAT4 highlight;
     std::vector<TextureAttachment> textures;
-    ID3D11ShaderResourceView* texture;
+    Texture* texture;
 };
 
 const std::type_index tid_UIPanel = std::type_index(typeid(UIPanel));
@@ -64,7 +65,6 @@ struct UIButton {
     // Perhaps later, this could be changed by specifying what component types the function affects, and with what permissions.
     std::function<void()> onPress;
 };
-
 
 const std::type_index tid_UIButton = std::type_index(typeid(UIButton));
 
@@ -78,7 +78,7 @@ public:
     ~UIHandler();
 
     void createPanel(Entity entity, DirectX::XMFLOAT2 pos, DirectX::XMFLOAT2 size, DirectX::XMFLOAT4 highlight, float highlightFactor);
-    void attachTextures(Entity entity, const TextureAttachmentInfo* attachmentInfos, ID3D11ShaderResourceView** textures, size_t textureCount);
+    void attachTextures(Entity entity, const TextureAttachmentInfo* pAttachmentInfos, TextureReference* pTextureReferences, size_t textureCount);
 
     // Requires that the entity has a UI panel already
     void createButton(Entity entity, DirectX::XMFLOAT4 hoverHighlight, DirectX::XMFLOAT4 pressHighlight,
@@ -90,7 +90,7 @@ public:
 private:
     // Creates a texture for a panel, which can be used as both a RTV and SRV
     void createPanelTexture(UIPanel& panel);
-    void createTextureAttachment(TextureAttachment& attachment, const TextureAttachmentInfo& attachmentInfo, ID3D11ShaderResourceView* texture, const UIPanel& panel);
+    void createTextureAttachment(TextureAttachment& attachment, const TextureAttachmentInfo& attachmentInfo, const TextureReference& texture, const UIPanel& panel);
     void renderTexturesOntoPanel(const std::vector<TextureAttachment>& attachments, UIPanel& panel);
 private:
     ID3D11Device* m_pDevice;

--- a/GameProject/Engine/UI/UIRenderer.cpp
+++ b/GameProject/Engine/UI/UIRenderer.cpp
@@ -86,7 +86,7 @@ void UIRenderer::update(float dt)
 
     for (const Entity& entity : panels.getVec()) {
         UIPanel& panel = UIhandler->panels.indexID(entity);
-        if (panel.texture == nullptr) {
+        if (panel.texture->getSRV() == nullptr) {
             continue;
         }
 
@@ -98,7 +98,8 @@ void UIRenderer::update(float dt)
         context->VSSetConstantBuffers(0, 1, perPanelBuffer.GetAddressOf());
         context->PSSetConstantBuffers(0, 1, perPanelBuffer.GetAddressOf());
 
-        context->PSSetShaderResources(0, 1, &panel.texture);
+        ID3D11ShaderResourceView* pPanelSRV = panel.texture->getSRV();
+        context->PSSetShaderResources(0, 1, &pPanelSRV);
 
         context->Draw(4, 0);
     }

--- a/GameProject/Game/States/MainMenu.cpp
+++ b/GameProject/Game/States/MainMenu.cpp
@@ -32,8 +32,8 @@ MainMenu::MainMenu(StateManager* stateManager, ECSInterface* ecs, ID3D11Device* 
     uiHandler->createPanel(uiEntity, {0.4f, 0.45f}, {0.2f, 0.1f}, {0.0f, 0.0f, 0.0f, 0.0f}, 1.0f);
 
     // Attach background and text textures to the panel
-    ID3D11ShaderResourceView* panelTextures[2] = {
-        pTextureLoader->loadTexture("./Game/Assets/Models/Cube.png").srv,
+    TextureReference panelTextures[2] = {
+        pTextureLoader->loadTexture("./Game/Assets/Models/Cube.png"),
         pTextRenderer->renderText("Play", "Game/Assets/Fonts/arial/arial.ttf", 50)
     };
 


### PR DESCRIPTION
Changed how texture data is deleted. Previously, services or component handlers would have to delete them, now they also delete themselves when a reference count drops to 0.