### PR TITLE
ECS Booter

### DIFF
--- a/GameProject/Engine/ECS/ComponentHandler.cpp
+++ b/GameProject/Engine/ECS/ComponentHandler.cpp
@@ -6,18 +6,16 @@ ComponentHandler::ComponentHandler(std::vector<std::type_index> handledTypes, EC
     :m_HandledTypes(handledTypes),
     m_pECS(pECS),
     m_TID(tid_handler)
-{
-    m_pECS->getSystemSubscriber()->registerHandler(this, tid_handler);
-}
+{}
 
 ComponentHandler::~ComponentHandler()
 {
     m_pECS->getSystemSubscriber()->deregisterComponentHandler(this);
 }
 
-void ComponentHandler::registerHandler(std::vector<ComponentRegistration>* componentQueries)
+void ComponentHandler::registerHandler(const ComponentHandlerRegistration& handlerRegistration)
 {
-    m_pECS->getSystemSubscriber()->registerComponentHandler(componentQueries);
+    m_pECS->enqueueComponentHandlerRegistration(handlerRegistration);
 }
 
 const std::vector<std::type_index>& ComponentHandler::getHandledTypes() const

--- a/GameProject/Engine/ECS/ComponentHandler.hpp
+++ b/GameProject/Engine/ECS/ComponentHandler.hpp
@@ -10,8 +10,16 @@ class IDContainer;
 
 struct ComponentRegistration {
     std::type_index tid;
-    IDContainer* componentContainer;
+    IDContainer* pComponentContainer;
     std::function<void(Entity)> m_ComponentDestructor;
+};
+
+class ComponentHandler;
+
+struct ComponentHandlerRegistration {
+    ComponentHandler* pComponentHandler;
+    std::vector<ComponentRegistration> ComponentRegistrations;
+    std::vector<std::type_index> HandlerDependencies;
 };
 
 /*
@@ -26,6 +34,8 @@ public:
     // Deregisters component handler and deletes components
     ~ComponentHandler();
 
+    virtual bool init() = 0;
+
     const std::vector<std::type_index>& getHandledTypes() const;
     std::type_index getHandlerType() const;
 
@@ -34,14 +44,15 @@ protected:
      * Registers the component handler's type of components it handles
      * @param componentQueries Functions for asking if an entity has a component of a certain type
      */
-    void registerHandler(std::vector<ComponentRegistration>* componentQueries);
+    void registerHandler(const ComponentHandlerRegistration& handlerRegistration);
 
-    // Tell the system handler a component has been created
+    // Tell the system subscriber a component has been created
     void registerComponent(Entity entity, std::type_index componentType);
 
+protected:
+    ECSCore* m_pECS;
     std::vector<std::type_index> m_HandledTypes;
 
 private:
     std::type_index m_TID;
-    ECSCore* m_pECS;
 };

--- a/GameProject/Engine/ECS/ECSBooter.cpp
+++ b/GameProject/Engine/ECS/ECSBooter.cpp
@@ -1,0 +1,165 @@
+#include "ECSBooter.hpp"
+
+#include <Engine/ECS/ComponentHandler.hpp>
+#include <Engine/ECS/ECSCore.hpp>
+#include <Engine/ECS/System.hpp>
+#include <Engine/Utils/Logger.hpp>
+
+ECSBooter::ECSBooter(ECSCore* pECS)
+    :m_pECS(pECS)
+{}
+
+ECSBooter::~ECSBooter()
+{}
+
+void ECSBooter::enqueueComponentHandlerRegistration(const ComponentHandlerRegistration& handlerRegistration)
+{
+    m_ComponentHandlersToRegister.push_back(handlerRegistration);
+}
+
+void ECSBooter::enqueueSystemRegistration(const SystemRegistration& systemRegistration)
+{
+    m_SystemsToRegister.push_back(systemRegistration);
+}
+
+void ECSBooter::performBootups()
+{
+    if (m_ComponentHandlersToRegister.empty() && m_SystemsToRegister.empty()) {
+        return;
+    }
+
+    bootHandlers();
+    bootSystems();
+
+    m_ComponentHandlersToRegister.clear();
+    m_SystemsToRegister.clear();
+}
+
+void ECSBooter::bootHandlers()
+{
+    buildBootInfos();
+    finalizeHandlerBootDependencies();
+
+    auto currentHandlerItr = m_HandlersBootInfos.begin();
+
+    // Contains iterators to the current handler's dependencies
+    std::vector<std::unordered_map<std::type_index, ComponentHandlerBootInfo>::iterator> openList;
+    openList.reserve(m_HandlersBootInfos.size());
+
+    // Outer loop: goes through handlers in m_HandlersToBoot until each handler has been booted
+    while (currentHandlerItr != m_HandlersBootInfos.end()) {
+        // Inner loop: recursively goes through the current handler's dependencies until it is booted
+        auto dependencyItr = currentHandlerItr;
+
+        while (!currentHandlerItr->second.inClosedList) {
+            ComponentHandlerBootInfo& bootInfo = dependencyItr->second;
+            if (bootInfo.inOpenList) {
+                if (dependencyItr != openList.back()) {
+                    Logger::LOG_WARNING("Detected cyclic dependencies between component handlers, can not boot: %s", currentHandlerItr->first.name());
+                    break;
+                }
+            } else {
+                openList.push_back(dependencyItr);
+                bootInfo.inOpenList = true;
+            }
+
+            // Check if the handler has any unbooted dependencies
+            auto unbootedDependencyItr = m_HandlersBootInfos.end();
+
+            for (auto dependency : bootInfo.dependencyMapIterators) {
+                if (!dependency->second.inClosedList) {
+                    unbootedDependencyItr = dependency;
+                    break;
+                }
+            }
+
+            if (unbootedDependencyItr == m_HandlersBootInfos.end()) {
+                // All dependencies are booted, boot the handler
+                bootHandler(bootInfo);
+                openList.pop_back();
+
+                if (!openList.empty()) {
+                    dependencyItr = openList.back();
+                }
+            } else {
+                // Not all dependencies are booted, try to boot a dependency
+                dependencyItr = unbootedDependencyItr;
+            }
+        }
+
+        currentHandlerItr++;
+        openList.clear();
+    }
+
+    m_HandlersBootInfos.clear();
+}
+
+void ECSBooter::bootSystems()
+{
+    SystemSubscriber* pSystemSubscriber = m_pECS->getSystemSubscriber();
+
+    for (const SystemRegistration& systemReg : m_SystemsToRegister) {
+        if (!systemReg.system->init()) {
+            Logger::LOG_WARNING("Failed to initialize system, ID: %d", systemReg.system->ID);
+        } else {
+            pSystemSubscriber->registerSystem(systemReg);
+        }
+    }
+}
+
+void ECSBooter::buildBootInfos()
+{
+    for (const ComponentHandlerRegistration& handlerReg : m_ComponentHandlersToRegister) {
+        ComponentHandlerBootInfo bootInfo = {};
+        bootInfo.handlerRegistration = &handlerReg;
+        bootInfo.dependencyMapIterators.reserve(handlerReg.HandlerDependencies.size());
+        bootInfo.inOpenList = false;
+        bootInfo.inClosedList = false;
+
+        // Map the handler's type index to its boot info
+        m_HandlersBootInfos[handlerReg.pComponentHandler->getHandlerType()] = bootInfo;
+    }
+}
+
+void ECSBooter::finalizeHandlerBootDependencies()
+{
+    auto bootInfoItr = m_HandlersBootInfos.begin();
+    while (bootInfoItr != m_HandlersBootInfos.end()) {
+        ComponentHandlerBootInfo& bootInfo = bootInfoItr->second;
+        bool hasDependencies = true;
+
+        for (const std::type_index& dependencyTID : bootInfo.handlerRegistration->HandlerDependencies) {
+            // Find the dependency's index
+            auto dependencyItr = m_HandlersBootInfos.find(dependencyTID);
+            if (dependencyItr != m_HandlersBootInfos.end()) {
+                // The dependency is enqueued for bootup, store its iterator
+                bootInfo.dependencyMapIterators.push_back(dependencyItr);
+            } else {
+                // The dependency is not enqueued for bootup, it might already be booted
+                if (!m_pECS->getSystemSubscriber()->getComponentHandler(dependencyTID)) {
+                    Logger::LOG_WARNING("Cannot boot handler: %s, missing dependency: %s", bootInfo.handlerRegistration->pComponentHandler->getHandlerType().name(), dependencyTID.name());
+                    hasDependencies = false;
+                    break;
+                }
+            }
+        }
+
+        if (hasDependencies) {
+            bootInfoItr++;
+        } else {
+            bootInfoItr = m_HandlersBootInfos.erase(bootInfoItr);
+        }
+    }
+}
+
+void ECSBooter::bootHandler(ComponentHandlerBootInfo& bootInfo)
+{
+    bootInfo.inOpenList = false;
+    bootInfo.inClosedList = true;
+
+    if (!bootInfo.handlerRegistration->pComponentHandler->init()) {
+        Logger::LOG_WARNING("Failed to initialize component handler: %s", bootInfo.handlerRegistration->pComponentHandler->getHandlerType().name());
+    } else {
+        m_pECS->getSystemSubscriber()->registerComponentHandler(*bootInfo.handlerRegistration);
+    }
+}

--- a/GameProject/Engine/ECS/ECSBooter.hpp
+++ b/GameProject/Engine/ECS/ECSBooter.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <typeindex>
+#include <queue>
+#include <vector>
+#include <unordered_map>
+
+class ComponentHandler;
+class ECSCore;
+struct ComponentHandlerRegistration;
+struct SystemRegistration;
+
+struct ComponentHandlerBootInfo {
+    const ComponentHandlerRegistration* handlerRegistration = nullptr;
+    // Iterators that point out a handler's place in the boot info map
+    std::vector<std::unordered_map<std::type_index, ComponentHandlerBootInfo>::iterator> dependencyMapIterators;
+    // Used during bootup, to detect cyclic dependencies
+    bool inOpenList = false, inClosedList = false;
+};
+
+class ECSBooter
+{
+public:
+    ECSBooter(ECSCore* pECS);
+    ~ECSBooter();
+
+    void enqueueComponentHandlerRegistration(const ComponentHandlerRegistration& handlerRegistration);
+    void enqueueSystemRegistration(const SystemRegistration& systemRegistration);
+
+    void performBootups();
+
+private:
+    struct OpenListInfo {
+        ComponentHandlerBootInfo& bootInfo;
+        bool inOpenList, inClosedList;
+    };
+
+private:
+    void bootHandlers();
+    void bootSystems();
+
+    void buildBootInfos();
+    // Get the map iterators of each handler's dependency, for faster lookups. Also remove dependencies that have already been booted.
+    void finalizeHandlerBootDependencies();
+    void bootHandler(ComponentHandlerBootInfo& bootInfo);
+
+private:
+    ECSCore* m_pECS;
+
+    std::vector<ComponentHandlerRegistration> m_ComponentHandlersToRegister;
+    std::vector<SystemRegistration> m_SystemsToRegister;
+
+    // Maps handlers' types to their boot info
+    std::unordered_map<std::type_index, ComponentHandlerBootInfo> m_HandlersBootInfos;
+};

--- a/GameProject/Engine/ECS/ECSCore.cpp
+++ b/GameProject/Engine/ECS/ECSCore.cpp
@@ -1,15 +1,39 @@
 #include "ECSCore.hpp"
 
 ECSCore::ECSCore()
-    :m_SystemSubscriber(&m_EntityRegistry)
+    :m_SystemSubscriber(&m_EntityRegistry),
+    m_ECSBooter(this)
 {}
 
 ECSCore::~ECSCore()
 {}
 
+void ECSCore::update(float dt)
+{
+    performRegistrations();
+
+    m_SystemUpdater.updateMT(dt);
+}
+
 Entity ECSCore::createEntity()
 {
     return m_EntityRegistry.createEntity();
+}
+
+void ECSCore::enqueueComponentHandlerRegistration(const ComponentHandlerRegistration& handlerRegistration)
+{
+    m_ECSBooter.enqueueComponentHandlerRegistration(handlerRegistration);
+}
+
+void ECSCore::enqueueSystemRegistration(const SystemRegistration& systemRegistration)
+{
+    m_ECSBooter.enqueueSystemRegistration(systemRegistration);
+}
+
+void ECSCore::performRegistrations()
+{
+    // Initialize and register systems and component handlers
+    m_ECSBooter.performBootups();
 }
 
 void ECSCore::deleteEntityDelayed(Entity entity)

--- a/GameProject/Engine/ECS/ECSCore.hpp
+++ b/GameProject/Engine/ECS/ECSCore.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <Engine/ECS/ComponentHandler.hpp>
+#include <Engine/ECS/ECSBooter.hpp>
 #include <Engine/ECS/EntityRegistry.hpp>
+#include <Engine/ECS/System.hpp>
 #include <Engine/ECS/SystemSubscriber.hpp>
 #include <Engine/ECS/SystemUpdater.hpp>
 #include <Engine/Utils/IDGenerator.hpp>
@@ -16,7 +19,14 @@ public:
     ECSCore(const ECSCore& other) = delete;
     void operator=(const ECSCore& other) = delete;
 
+    void update(float dt);
+
     Entity createEntity();
+
+    void enqueueComponentHandlerRegistration(const ComponentHandlerRegistration& handlerRegistration);
+    void enqueueSystemRegistration(const SystemRegistration& systemRegistration);
+    // Registers and initializes component handlers and systems
+    void performRegistrations();
 
     // Enqueues an entity deletion, performed during maintenance
     void deleteEntityDelayed(Entity entity);
@@ -38,6 +48,7 @@ private:
     EntityRegistry m_EntityRegistry;
     SystemSubscriber m_SystemSubscriber;
     SystemUpdater m_SystemUpdater;
+    ECSBooter m_ECSBooter;
 
     std::vector<Entity> m_EntitiesToDelete;
 };

--- a/GameProject/Engine/ECS/System.cpp
+++ b/GameProject/Engine/ECS/System.cpp
@@ -12,9 +12,9 @@ System::~System()
     m_pECS->getSystemSubscriber()->deregisterSystem(this, componentTypes);
 }
 
-void System::subscribeToComponents(SystemRegistration* sysReg)
+void System::subscribeToComponents(const SystemRegistration& sysReg)
 {
-    m_pECS->getSystemSubscriber()->registerSystem(sysReg);
+    m_pECS->enqueueSystemRegistration(sysReg);
 }
 
 void System::registerUpdate(SystemRegistration* sysReg)

--- a/GameProject/Engine/ECS/System.hpp
+++ b/GameProject/Engine/ECS/System.hpp
@@ -49,12 +49,14 @@ public:
     // Deregisters system
     ~System();
 
+    virtual bool init() = 0;
+
     virtual void update(float dt) = 0;
 
     size_t ID;
 
 protected:
-    void subscribeToComponents(SystemRegistration* sysReg);
+    void subscribeToComponents(const SystemRegistration& sysReg);
     void registerUpdate(SystemRegistration* sysReg);
 
     void unsubscribeFromComponents(std::vector<std::type_index> unsubTypes);

--- a/GameProject/Engine/ECS/SystemSubscriber.hpp
+++ b/GameProject/Engine/ECS/SystemSubscriber.hpp
@@ -14,8 +14,7 @@
 #include <vector>
 
 class ComponentHandler;
-class IComponentContainer;
-struct ComponentRegistration;
+struct ComponentHandlerRegistration;
 
 struct ComponentSubscriptions {
     // Stores IDs of entities found using subscription
@@ -44,14 +43,11 @@ public:
     SystemSubscriber(EntityRegistry* pEntityRegistry);
     ~SystemSubscriber();
 
-    // Associates a component types with functions for querying for their existence given entity IDs
-    void registerComponentHandler(std::vector<ComponentRegistration>* componentRegs);
+    void registerComponentHandler(const ComponentHandlerRegistration& componentHandlerRegistration);
     void deregisterComponentHandler(ComponentHandler* handler);
-
-    void registerHandler(ComponentHandler* handler, const std::type_index& handlerType);
     ComponentHandler* getComponentHandler(const std::type_index& handlerType);
 
-    void registerSystem(SystemRegistration* sysReg);
+    void registerSystem(const SystemRegistration& sysReg);
     void deregisterSystem(System* system, std::vector<std::type_index>& componentTypes);
 
     // Notifies subscribed systems that a new component has been made

--- a/GameProject/Engine/GameState/StateManager.cpp
+++ b/GameProject/Engine/GameState/StateManager.cpp
@@ -56,12 +56,10 @@ void StateManager::transitionState(State* pNewState, STATE_TRANSITION transition
 
 void StateManager::update(float dt)
 {
-    // while (!m_StatesToDelete.empty()) {
-    //     delete m_StatesToDelete.front();
-    //     m_StatesToDelete.pop();
-    // }
-
     if (!m_States.empty()) {
         m_States.top()->update(dt);
+
+        m_pECS->performRegistrations();
+        m_pECS->getSystemUpdater()->updateMT(dt);
     }
 }

--- a/GameProject/Engine/IGame.cpp
+++ b/GameProject/Engine/IGame.cpp
@@ -21,6 +21,8 @@ IGame::IGame(HINSTANCE hInstance)
     cameraSystem(&m_ECS),
     buttonSystem(&m_ECS, display.getWindowWidth(), display.getWindowHeight())
 {
+    m_ECS.performRegistrations();
+
     display.showWindow();
     renderer.update(0.0f);
 }
@@ -41,11 +43,11 @@ void IGame::run()
         }
 
         if (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE)) {
-            TranslateMessage(&msg); 
-            DispatchMessage(&msg); 
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
         } else {
             timeNow = std::chrono::high_resolution_clock::now();
-            dtChrono = timeNow-timer;
+            dtChrono = timeNow - timer;
             float dt = dtChrono.count();
 
             timer = timeNow;

--- a/GameProject/Engine/InputHandler.cpp
+++ b/GameProject/Engine/InputHandler.cpp
@@ -1,40 +1,51 @@
 #include "InputHandler.hpp"
 
+#include <Engine/Utils/ECSUtils.hpp>
+
 InputHandler::InputHandler(ECSCore* pECS, HWND window)
-    :ComponentHandler({}, pECS, std::type_index(typeid(InputHandler)))
+    :ComponentHandler({}, pECS, TID(InputHandler)),
+    m_Window(window)
 {
-    mouse.SetWindow(window);
-    mouse.SetMode(mouse.MODE_RELATIVE);
+    ComponentHandlerRegistration handlerReg = {};
+    handlerReg.pComponentHandler = this;
+    registerHandler(handlerReg);
 }
 
 InputHandler::~InputHandler()
 {}
 
+bool InputHandler::init()
+{
+    m_Mouse.SetWindow(m_Window);
+    m_Mouse.SetMode(m_Mouse.MODE_RELATIVE);
+    return true;
+}
+
 void InputHandler::update()
 {
-    keyboardState = keyboard.GetState();
-    mouseState = mouse.GetState();
-    mouseBtnTracker.Update(mouseState);
+    m_KeyboardState = m_Keyboard.GetState();
+    m_MouseState = m_Mouse.GetState();
+    m_MouseBtnTracker.Update(m_MouseState);
 }
 
 DirectX::Keyboard::State* InputHandler::getKeyboardState()
 {
-    return &keyboardState;
+    return &m_KeyboardState;
 }
 
 DirectX::Mouse::State* InputHandler::getMouseState()
 {
-    return &mouseState;
+    return &m_MouseState;
 }
 
 void InputHandler::setMouseMode(DirectX::Mouse::Mode mode)
 {
-    mouse.SetMode(mode);
+    m_Mouse.SetMode(mode);
 }
 
 void InputHandler::setMouseVisibility(bool visible)
 {
     ShowCursor(visible);
-    mouse.SetVisible(visible);
+    m_Mouse.SetVisible(visible);
     ShowCursor(visible);
 }

--- a/GameProject/Engine/InputHandler.hpp
+++ b/GameProject/Engine/InputHandler.hpp
@@ -12,6 +12,8 @@ public:
     InputHandler(ECSCore* pECS, HWND window);
     ~InputHandler();
 
+    virtual bool init() override;
+
     // Updates the states of the keyboard and mouse
     void update();
 
@@ -22,10 +24,12 @@ public:
     void setMouseVisibility(bool visible);
 
 private:
-    DirectX::Keyboard keyboard;
-    DirectX::Keyboard::State keyboardState;
+    DirectX::Keyboard m_Keyboard;
+    DirectX::Keyboard::State m_KeyboardState;
 
-    DirectX::Mouse mouse;
-    DirectX::Mouse::State mouseState;
-    DirectX::Mouse::ButtonStateTracker mouseBtnTracker;
+    DirectX::Mouse m_Mouse;
+    DirectX::Mouse::State m_MouseState;
+    DirectX::Mouse::ButtonStateTracker m_MouseBtnTracker;
+
+    HWND m_Window;
 };

--- a/GameProject/Engine/Rendering/AssetContainers/Model.hpp
+++ b/GameProject/Engine/Rendering/AssetContainers/Model.hpp
@@ -25,10 +25,10 @@ struct Model {
     std::vector<Material> materials;
 };
 
-inline void releaseModel(Model* model)
+inline void releaseModel(Model* pModel)
 {
-    for (size_t i = 0; i < model->meshes.size(); i += 1) {
-        model->meshes[i].vertexBuffer->Release();
-        model->meshes[i].indexBuffer->Release();
+    for (size_t i = 0; i < pModel->meshes.size(); i += 1) {
+        pModel->meshes[i].vertexBuffer->Release();
+        pModel->meshes[i].indexBuffer->Release();
     }
 }

--- a/GameProject/Engine/Rendering/AssetLoaders/ModelLoader.hpp
+++ b/GameProject/Engine/Rendering/AssetLoaders/ModelLoader.hpp
@@ -20,6 +20,8 @@ public:
     ModelLoader(ECSCore* pECS, TextureLoader* txLoader);
     ~ModelLoader();
 
+    virtual bool init() override;
+
     Model* loadModel(const std::string& filePath);
 
     void deleteAllModels();
@@ -31,11 +33,12 @@ private:
     void loadMesh(const aiMesh* assimpMesh, std::vector<Mesh>& meshes);
     void loadMaterial(const aiMaterial* assimpMaterial, std::vector<Material>& materials, const std::string& directory);
 
-    TextureLoader* txLoader;
-    ShaderResourceHandler* shaderResourceHandler;
-
-    // Recursively traverse scene nodes to find out which meshes are used
+    // Recursively traverse assimp scene nodes to find out which meshes are used
     void loadNode(std::vector<unsigned int>& meshIndices, aiNode* node, const aiScene* scene);
 
-    std::unordered_map<std::string, Model*> models;
+private:
+    TextureLoader* m_pTXLoader;
+    ShaderResourceHandler* m_pShaderResourceHandler;
+
+    std::unordered_map<std::string, Model*> m_Models;
 };

--- a/GameProject/Engine/Rendering/AssetLoaders/TextureLoader.hpp
+++ b/GameProject/Engine/Rendering/AssetLoaders/TextureLoader.hpp
@@ -8,15 +8,17 @@
 class TextureLoader : public ComponentHandler
 {
 public:
-    TextureLoader(ECSCore* pECS, ID3D11Device* device);
+    TextureLoader(ECSCore* pECS, ID3D11Device* pDevice);
     ~TextureLoader();
+
+    virtual bool init() override;
 
     TextureReference loadTexture(const std::string& filePath);
 
     void deleteAllTextures();
 
 private:
-    std::unordered_map<std::string, Texture*> textures;
+    std::unordered_map<std::string, Texture*> m_Textures;
 
-    ID3D11Device* device;
+    ID3D11Device* m_pDevice;
 };

--- a/GameProject/Engine/Rendering/Camera.cpp
+++ b/GameProject/Engine/Rendering/Camera.cpp
@@ -3,71 +3,73 @@
 #include <Engine/Rendering/Components/VPMatrices.hpp>
 #include <Engine/InputHandler.hpp>
 #include <Engine/Transform.hpp>
+#include <Engine/Utils/ECSUtils.hpp>
 
 CameraSystem::CameraSystem(ECSCore* pECS)
     :System(pECS)
 {
-    std::type_index tid_transformHandler = std::type_index(typeid(TransformHandler));
-    std::type_index tid_vpHandler = std::type_index(typeid(VPHandler));
-    std::type_index tid_inputHandler = std::type_index(typeid(InputHandler));
-
-    this->transformHandler = static_cast<TransformHandler*>(getComponentHandler(tid_transformHandler));
-    this->vpHandler = static_cast<VPHandler*>(getComponentHandler(tid_vpHandler));
-
-    InputHandler* inputHandler = static_cast<InputHandler*>(getComponentHandler(tid_inputHandler));
-    this->keyboardState = inputHandler->getKeyboardState();
-    this->mouseState = inputHandler->getMouseState();
-
     SystemRegistration sysReg = {
     {
-        {{{RW, tid_transform}, {RW, tid_view}, {R, tid_projection}}, &cameras},
+        {{{RW, tid_transform}, {RW, tid_view}, {R, tid_projection}}, &m_Cameras},
     },
     this};
 
-    this->subscribeToComponents(&sysReg);
+    this->subscribeToComponents(sysReg);
     this->registerUpdate(&sysReg);
 }
 
 CameraSystem::~CameraSystem()
 {}
 
+bool CameraSystem::init()
+{
+    this->m_pTransformHandler = static_cast<TransformHandler*>(getComponentHandler(TID(TransformHandler)));
+    this->m_pVPHandler = static_cast<VPHandler*>(getComponentHandler(TID(VPHandler)));
+
+    InputHandler* pInputHandler = static_cast<InputHandler*>(getComponentHandler(TID(InputHandler)));
+    this->m_pKeyboardState = pInputHandler->getKeyboardState();
+    this->m_pMouseState = pInputHandler->getMouseState();
+
+    return m_pTransformHandler && m_pVPHandler && pInputHandler;
+}
+
 void CameraSystem::update(float dt)
 {
-    for (size_t i = 0; i < cameras.size(); i += 1) {
-        Transform& camTransform = transformHandler->transforms.indexID(cameras[i]);
-        ViewMatrix& viewMatrix = vpHandler->viewMatrices.indexID(cameras[i]);
+    for (size_t i = 0; i < m_Cameras.size(); i += 1) {
+        Transform& camTransform = m_pTransformHandler->transforms.indexID(m_Cameras[i]);
+        ViewMatrix& viewMatrix = m_pVPHandler->viewMatrices.indexID(m_Cameras[i]);
 
-        DirectX::XMVECTOR lookDir = transformHandler->getForward(camTransform.rotQuat);
+        DirectX::XMVECTOR lookDir = m_pTransformHandler->getForward(camTransform.rotQuat);
         DirectX::XMVECTOR pitchAxis = DirectX::XMVector3Normalize(DirectX::XMVector3Cross(defaultUp, lookDir));
 
         // React to mouse input
-        if (mouseState->x || mouseState->y) {
+        if (m_pMouseState->x || m_pMouseState->y) {
             DirectX::XMVECTOR rotation = DirectX::XMLoadFloat4(&camTransform.rotQuat);
 
             // Limit pitch
-            float pitch = transformHandler->getPitch(lookDir);
-            float addedPitch = mouseState->y * dt * 1.3f;
+            float pitch = m_pTransformHandler->getPitch(lookDir);
+            float addedPitch = m_pMouseState->y * dt * 1.3f;
             float newPitch = pitch + addedPitch;
 
             if (std::abs(newPitch) > maxPitch) {
                 addedPitch = newPitch > 0.0f ? maxPitch - pitch : -maxPitch - pitch;
             }
 
-            rotation = DirectX::XMQuaternionMultiply(rotation, DirectX::XMQuaternionRotationAxis(defaultUp, mouseState->x * dt * 1.3f));
+            rotation = DirectX::XMQuaternionMultiply(rotation, DirectX::XMQuaternionRotationAxis(defaultUp, m_pMouseState->x * dt * 1.3f));
             rotation = DirectX::XMQuaternionMultiply(rotation, DirectX::XMQuaternionRotationAxis(pitchAxis, addedPitch));
             DirectX::XMStoreFloat4(&camTransform.rotQuat, rotation);
-            lookDir = transformHandler->getForward(camTransform.rotQuat);
+            lookDir = m_pTransformHandler->getForward(camTransform.rotQuat);
         }
 
         DirectX::XMVECTOR camPos = DirectX::XMLoadFloat3(&camTransform.position);
 
         // React to keyboard input
-        if ((keyboardState->W-keyboardState->S) || (keyboardState->D-keyboardState->A) || (keyboardState->LeftShift-keyboardState->LeftControl)) {
+        if ((m_pKeyboardState->W-m_pKeyboardState->S) || (m_pKeyboardState->D-m_pKeyboardState->A) || (m_pKeyboardState->LeftShift-m_pKeyboardState->LeftControl)) {
             DirectX::XMVECTOR camMove = {0.0f, 0.0f, 0.0f, 0.0f};
 
-            camMove = DirectX::XMVectorAdd(camMove, DirectX::XMVectorScale(lookDir, (float)(keyboardState->W-keyboardState->S)));
-            camMove = DirectX::XMVectorAdd(camMove, DirectX::XMVectorScale(pitchAxis, (float)(keyboardState->D-keyboardState->A)));
-            camMove = DirectX::XMVectorAdd(camMove, DirectX::XMVectorScale(defaultUp, (float)(keyboardState->LeftShift-keyboardState->LeftControl)));
+            camMove = DirectX::XMVectorAdd(camMove, DirectX::XMVectorScale(lookDir, (float)(m_pKeyboardState->W-m_pKeyboardState->S)));
+            camMove = DirectX::XMVectorAdd(camMove, DirectX::XMVectorScale(pitchAxis, (float)(m_pKeyboardState->D-m_pKeyboardState->A)));
+            camMove = DirectX::XMVectorAdd(camMove, DirectX::XMVectorScale(defaultUp, (float)(m_pKeyboardState->LeftShift-m_pKeyboardState->LeftControl)));
 
             camMove = DirectX::XMVectorScale(DirectX::XMVector3Normalize(camMove), dt * 1.5f);
             camPos = DirectX::XMVectorAdd(camPos, camMove);

--- a/GameProject/Engine/Rendering/Camera.hpp
+++ b/GameProject/Engine/Rendering/Camera.hpp
@@ -17,14 +17,16 @@ public:
     CameraSystem(ECSCore* pECS);
     ~CameraSystem();
 
+    virtual bool init() override;
+
     // Keeps cameras' view matrices up-to date with their transforms
     void update(float dt);
 
 private:
-    IDVector<Entity> cameras;
+    IDVector<Entity> m_Cameras;
 
-    TransformHandler* transformHandler;
-    VPHandler *vpHandler;
-    DirectX::Keyboard::State* keyboardState;
-    DirectX::Mouse::State* mouseState;
+    TransformHandler* m_pTransformHandler;
+    VPHandler* m_pVPHandler;
+    DirectX::Keyboard::State* m_pKeyboardState;
+    DirectX::Mouse::State* m_pMouseState;
 };

--- a/GameProject/Engine/Rendering/Components/PointLight.cpp
+++ b/GameProject/Engine/Rendering/Components/PointLight.cpp
@@ -1,17 +1,24 @@
 #include "PointLight.hpp"
 
 LightHandler::LightHandler(ECSCore* pECS)
-    :ComponentHandler({tid_pointLight}, pECS, std::type_index(typeid(LightHandler)))
+    :ComponentHandler({tid_pointLight}, pECS, TID(LightHandler))
 {
-    std::vector<ComponentRegistration> compRegs = {
+    ComponentHandlerRegistration handlerReg = {};
+    handlerReg.pComponentHandler = this;
+    handlerReg.ComponentRegistrations = {
         {tid_pointLight, &pointLights}
     };
 
-    this->registerHandler(&compRegs);
+    this->registerHandler(handlerReg);
 }
 
 LightHandler::~LightHandler()
 {}
+
+bool LightHandler::init()
+{
+    return true;
+}
 
 void LightHandler::createPointLight(Entity entity, DirectX::XMFLOAT3 position, DirectX::XMFLOAT3 light, float radius)
 {

--- a/GameProject/Engine/Rendering/Components/PointLight.hpp
+++ b/GameProject/Engine/Rendering/Components/PointLight.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Engine/ECS/ComponentHandler.hpp>
+#include <Engine/Utils/ECSUtils.hpp>
 #include <Engine/Utils/IDVector.hpp>
 #include <DirectXMath.h>
 
@@ -12,13 +13,15 @@ struct PointLight
     float padding;
 };
 
-const std::type_index tid_pointLight = std::type_index(typeid(PointLight));
+const std::type_index tid_pointLight = TID(PointLight);
 
 class LightHandler : public ComponentHandler
 {
 public:
     LightHandler(ECSCore* pECS);
     ~LightHandler();
+
+    virtual bool init() override;
 
     void createPointLight(Entity entity, DirectX::XMFLOAT3 position, DirectX::XMFLOAT3 light, float radius);
 

--- a/GameProject/Engine/Rendering/Components/Renderable.hpp
+++ b/GameProject/Engine/Rendering/Components/Renderable.hpp
@@ -4,6 +4,7 @@
 #include <Engine/ECS/ComponentHandler.hpp>
 #include <Engine/Rendering/ShaderHandler.hpp>
 #include <Engine/Utils/IDVector.hpp>
+#include <Engine/Utils/ECSUtils.hpp>
 #include <string>
 #include <typeindex>
 
@@ -16,21 +17,23 @@ struct Renderable {
     Program* program;
 };
 
-const std::type_index tid_renderable = std::type_index(typeid(Renderable));
+const std::type_index tid_renderable = TID(Renderable);
 
 class RenderableHandler : public ComponentHandler
 {
 public:
     RenderableHandler(ECSCore* pECS);
 
+    virtual bool init() override;
+
     // Creates a renderable component by loading from file
     bool createRenderable(Entity entity, std::string modelPath, PROGRAM program);
     // Creates a renderable component out of an existing model
     bool createRenderable(Entity entity, Model* model, PROGRAM program);
 
-    IDVector<Renderable> renderables;
+    IDVector<Renderable> m_Renderables;
 
 private:
-    ShaderHandler* shaderHandler;
-    ModelLoader* modelLoader;
+    ShaderHandler* m_pShaderHandler;
+    ModelLoader* m_pModelLoader;
 };

--- a/GameProject/Engine/Rendering/Components/VPMatrices.cpp
+++ b/GameProject/Engine/Rendering/Components/VPMatrices.cpp
@@ -3,18 +3,25 @@
 const float degreesToRadians = DirectX::XM_PI / 180.0f;
 
 VPHandler::VPHandler(ECSCore* pECS)
-    :ComponentHandler({tid_view, tid_projection}, pECS, std::type_index(typeid(VPHandler)))
+    :ComponentHandler({tid_view, tid_projection}, pECS, TID(VPHandler))
 {
-    std::vector<ComponentRegistration> compRegs = {
+    ComponentHandlerRegistration handlerReg = {};
+    handlerReg.pComponentHandler = this;
+    handlerReg.ComponentRegistrations = {
         {tid_view, &viewMatrices},
         {tid_projection, &projMatrices}
     };
 
-    this->registerHandler(&compRegs);
+    this->registerHandler(handlerReg);
 }
 
 VPHandler::~VPHandler()
 {}
+
+bool VPHandler::init()
+{
+    return true;
+}
 
 void VPHandler::createViewMatrix(Entity entity, DirectX::XMVECTOR eyePos, DirectX::XMVECTOR lookDir, DirectX::XMVECTOR upDir)
 {

--- a/GameProject/Engine/Rendering/Components/VPMatrices.hpp
+++ b/GameProject/Engine/Rendering/Components/VPMatrices.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Engine/ECS/ComponentHandler.hpp>
+#include <Engine/Utils/ECSUtils.hpp>
 #include <Engine/Utils/IDVector.hpp>
 #include <DirectXMath.h>
 
@@ -12,14 +13,16 @@ struct ProjectionMatrix {
     DirectX::XMFLOAT4X4 projection;
 };
 
-const std::type_index tid_view = std::type_index(typeid(ViewMatrix));
-const std::type_index tid_projection = std::type_index(typeid(ProjectionMatrix));
+const std::type_index tid_view = TID(ViewMatrix);
+const std::type_index tid_projection = TID(ProjectionMatrix);
 
 class VPHandler : public ComponentHandler
 {
 public:
     VPHandler(ECSCore* pECS);
     ~VPHandler();
+
+    virtual bool init() override;
 
     void createViewMatrix(Entity entity, DirectX::XMVECTOR eyePos, DirectX::XMVECTOR lookDir, DirectX::XMVECTOR upDir);
     void createProjMatrix(Entity entity, float horizontalFOV, float aspectRatio, float nearZ, float farZ);

--- a/GameProject/Engine/Rendering/Renderer.hpp
+++ b/GameProject/Engine/Rendering/Renderer.hpp
@@ -11,46 +11,6 @@ class RenderableHandler;
 class TransformHandler;
 class VPHandler;
 
-class Renderer : public System
-{
-public:
-    Renderer(ECSCore* pECS, ID3D11Device* device, ID3D11DeviceContext* context, ID3D11RenderTargetView* rtv, ID3D11DepthStencilView* dsv);
-    ~Renderer();
-
-    void update(float dt);
-
-private:
-    RenderableHandler* renderableHandler;
-    TransformHandler* transformHandler;
-    VPHandler* vpHandler;
-    LightHandler* lightHandler;
-
-    IDVector<Entity> renderables;
-    IDVector<Entity> camera;
-    IDVector<Entity> pointLights;
-
-    ID3D11DeviceContext* context;
-
-    /* Mesh input layout */
-    ID3D11InputLayout* meshInputLayout;
-
-    /* Cbuffers */
-    // WVP and W matrices
-    ID3D11Buffer* perObjectMatrices;
-    ID3D11Buffer* materialBuffer;
-    // Contains pointlights, camera position and number of lights
-    ID3D11Buffer* pointLightBuffer;
-
-    /* Samplers */
-    ID3D11SamplerState *const* aniSampler;
-
-    /* Render targets */
-    ID3D11RenderTargetView* renderTarget;
-    ID3D11DepthStencilView* depthStencilView;
-
-    ID3D11RasterizerState* rsState;
-};
-
 struct PerObjectMatrices {
     DirectX::XMFLOAT4X4 WVP, world;
 };
@@ -60,4 +20,47 @@ struct PerFrameBuffer {
     DirectX::XMFLOAT3 cameraPosition;
     uint32_t numLights;
     DirectX::XMFLOAT4 padding;
+};
+
+class Renderer : public System
+{
+public:
+    Renderer(ECSCore* pECS, ID3D11Device* pDevice, ID3D11DeviceContext* pContext, ID3D11RenderTargetView* pRTV, ID3D11DepthStencilView* pDSV);
+    ~Renderer();
+
+    virtual bool init() override;
+
+    void update(float dt);
+
+private:
+    IDVector<Entity> renderables;
+    IDVector<Entity> camera;
+    IDVector<Entity> pointLights;
+
+    RenderableHandler* m_pRenderableHandler;
+    TransformHandler* m_pTransformHandler;
+    VPHandler* m_pVPHandler;
+    LightHandler* m_pLightHandler;
+
+    ID3D11Device* m_pDevice;
+    ID3D11DeviceContext* m_pContext;
+
+    /* Mesh input layout */
+    ID3D11InputLayout* m_pMeshInputLayout;
+
+    /* Cbuffers */
+    // WVP and W matrices
+    ID3D11Buffer* m_pPerObjectMatrices;
+    ID3D11Buffer* m_pMaterialBuffer;
+    // Contains pointlights, camera position and number of lights
+    ID3D11Buffer* m_pPointLightBuffer;
+
+    /* Samplers */
+    ID3D11SamplerState *const* m_ppAniSampler;
+
+    /* Render targets */
+    ID3D11RenderTargetView* m_pRenderTarget;
+    ID3D11DepthStencilView* m_pDepthStencilView;
+
+    ID3D11RasterizerState* m_RsState;
 };

--- a/GameProject/Engine/Rendering/ShaderHandler.hpp
+++ b/GameProject/Engine/Rendering/ShaderHandler.hpp
@@ -44,6 +44,8 @@ public:
     ShaderHandler(ID3D11Device* device, ECSCore* pECS);
     ~ShaderHandler();
 
+    virtual bool init() override;
+
     Program* getProgram(PROGRAM program);
 
 private:
@@ -51,7 +53,7 @@ private:
 
     ID3DBlob* compileShader(LPCWSTR fileName, LPCSTR entryPoint, LPCSTR targetVer);
 
-    std::vector<Program> programs;
+    std::vector<Program> m_Programs;
 
-    ID3D11Device* device;
+    ID3D11Device* m_pDevice;
 };

--- a/GameProject/Engine/Rendering/ShaderResourceHandler.hpp
+++ b/GameProject/Engine/Rendering/ShaderResourceHandler.hpp
@@ -14,8 +14,10 @@ public:
     ShaderResourceHandler(ECSCore* pECS, ID3D11Device* device);
     ~ShaderResourceHandler();
 
-    void createVertexBuffer(const void* vertices, size_t vertexSize, size_t vertexCount, ID3D11Buffer** targetBuffer);
-    void createIndexBuffer(unsigned* indices, size_t indexCount, ID3D11Buffer** targetBuffer);
+    virtual bool init() override;
+
+    bool createVertexBuffer(const void* vertices, size_t vertexSize, size_t vertexCount, ID3D11Buffer** targetBuffer);
+    bool createIndexBuffer(unsigned* indices, size_t indexCount, ID3D11Buffer** targetBuffer);
 
     ID3D11SamplerState *const* getAniSampler() const;
 

--- a/GameProject/Engine/Rendering/Text/TextRenderer.hpp
+++ b/GameProject/Engine/Rendering/Text/TextRenderer.hpp
@@ -32,6 +32,8 @@ public:
     TextRenderer(ECSCore* pECS, ID3D11Device* device, ID3D11DeviceContext* context);
     ~TextRenderer();
 
+    virtual bool init() override;
+
     // Creates a texture with text rendered onto it
     TextureReference renderText(const std::string& text, const std::string& font, unsigned int fontPixelHeight);
 

--- a/GameProject/Engine/Transform.cpp
+++ b/GameProject/Engine/Transform.cpp
@@ -5,18 +5,25 @@
 #include <cmath>
 
 TransformHandler::TransformHandler(ECSCore* pECS)
-    :ComponentHandler({tid_transform, tid_worldMatrix}, pECS, std::type_index(typeid(TransformHandler)))
+    :ComponentHandler({tid_transform, tid_worldMatrix}, pECS, TID(TransformHandler))
 {
-    std::vector<ComponentRegistration> compRegs = {
+    ComponentHandlerRegistration handlerReg = {};
+    handlerReg.pComponentHandler = this;
+    handlerReg.ComponentRegistrations = {
         {tid_transform, &transforms},
         {tid_worldMatrix, &worldMatrices}
     };
 
-    this->registerHandler(&compRegs);
+    this->registerHandler(handlerReg);
 }
 
 TransformHandler::~TransformHandler()
 {}
+
+bool TransformHandler::init()
+{
+    return true;
+}
 
 void TransformHandler::createTransform(Entity entity)
 {

--- a/GameProject/Engine/Transform.hpp
+++ b/GameProject/Engine/Transform.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Engine/ECS/ComponentHandler.hpp>
+#include <Engine/Utils/ECSUtils.hpp>
 #include <Engine/Utils/IDVector.hpp>
 #include <DirectXMath.h>
 
@@ -18,14 +19,16 @@ struct WorldMatrix {
     bool dirty;
 };
 
-const std::type_index tid_transform = std::type_index(typeid(Transform));
-const std::type_index tid_worldMatrix = std::type_index(typeid(WorldMatrix));
+const std::type_index tid_transform = TID(Transform);
+const std::type_index tid_worldMatrix = TID(WorldMatrix);
 
 class TransformHandler : public ComponentHandler
 {
 public:
     TransformHandler(ECSCore* pECs);
     ~TransformHandler();
+
+    virtual bool init() override;
 
     void createTransform(Entity entity);
     // Requires that the entity has a transform component

--- a/GameProject/Engine/UI/ButtonSystem.hpp
+++ b/GameProject/Engine/UI/ButtonSystem.hpp
@@ -11,23 +11,25 @@ public:
     ButtonSystem(ECSCore* pECS, unsigned int windowWidth, unsigned int windowHeight);
     ~ButtonSystem();
 
+    virtual bool init() override;
+
     void update(float dt);
 
 private:
-    IDVector<Entity> buttons;
+    IDVector<Entity> m_Buttons;
 
-    UIHandler* UIhandler;
+    UIHandler* m_pUIhandler;
 
     // Used for translating panel positions from [0,1] to [0, windowWidth or windowHeight]
-    unsigned int clientWidth, clientHeight;
+    unsigned int m_ClientWidth, m_ClientHeight;
 
-    DirectX::Mouse::State* mouseState;
+    DirectX::Mouse::State* m_pMouseState;
 
     // The bools are needed because the entity ID can't be set to -1 (it's unsigned).
     // Here, the assumption is made that only one button can be hovered or pressed at a time.
-    bool pressedButtonExists;
-    Entity pressedButton;
+    bool m_PressedButtonExists;
+    Entity m_PressedButton;
 
-    bool hoveredButtonExists;
-    Entity hoveredButton;
+    bool m_HoveredButtonExists;
+    Entity m_HoveredButton;
 };

--- a/GameProject/Engine/UI/Panel.hpp
+++ b/GameProject/Engine/UI/Panel.hpp
@@ -4,6 +4,7 @@
 
 #include <Engine/ECS/ComponentHandler.hpp>
 #include <Engine/Rendering/AssetContainers/Texture.hpp>
+#include <Engine/Utils/ECSUtils.hpp>
 #include <Engine/Utils/IDVector.hpp>
 
 #include <DirectXMath.h>
@@ -57,7 +58,7 @@ struct UIPanel {
     Texture* texture;
 };
 
-const std::type_index tid_UIPanel = std::type_index(typeid(UIPanel));
+const std::type_index tid_UIPanel = TID(UIPanel);
 
 struct UIButton {
     DirectX::XMFLOAT4 defaultHighlight, hoverHighlight, pressHighlight;
@@ -66,7 +67,7 @@ struct UIButton {
     std::function<void()> onPress;
 };
 
-const std::type_index tid_UIButton = std::type_index(typeid(UIButton));
+const std::type_index tid_UIButton = TID(UIButton);
 
 class Display;
 struct Program;
@@ -76,6 +77,8 @@ class UIHandler : public ComponentHandler
 public:
     UIHandler(ECSCore* pECS, Display* pDisplay);
     ~UIHandler();
+
+    virtual bool init() override;
 
     void createPanel(Entity entity, DirectX::XMFLOAT2 pos, DirectX::XMFLOAT2 size, DirectX::XMFLOAT4 highlight, float highlightFactor);
     void attachTextures(Entity entity, const TextureAttachmentInfo* pAttachmentInfos, TextureReference* pTextureReferences, size_t textureCount);

--- a/GameProject/Engine/UI/UIRenderer.hpp
+++ b/GameProject/Engine/UI/UIRenderer.hpp
@@ -13,31 +13,34 @@ struct Program;
 class UIRenderer : public System
 {
 public:
-    UIRenderer(ECSCore* pECS, ID3D11DeviceContext* context, ID3D11Device* device, ID3D11RenderTargetView* rtv, ID3D11DepthStencilView* dsv);
+    UIRenderer(ECSCore* pECS, ID3D11DeviceContext* pContext, ID3D11Device* pDevice, ID3D11RenderTargetView* pRTV, ID3D11DepthStencilView* pDSV);
     ~UIRenderer();
+
+    virtual bool init() override;
 
     void update(float dt);
 
 private:
-    IDVector<Entity> panels;
+    IDVector<Entity> m_Panels;
 
-    UIHandler* UIhandler;
+    UIHandler* m_pUIHandler;
 
-    ShaderHandler* shaderHandler;
+    ShaderHandler* m_pShaderHandler;
 
-    Program* UIProgram;
+    Program* m_pUIProgram;
 
-    ID3D11DeviceContext* context;
+    ID3D11Device* m_pDevice;
+    ID3D11DeviceContext* m_pContext;
 
-    Microsoft::WRL::ComPtr<ID3D11Buffer> quad;
+    Microsoft::WRL::ComPtr<ID3D11Buffer> m_Quad;
 
     /* Render targets */
-    ID3D11RenderTargetView* renderTarget;
-    ID3D11DepthStencilView* depthStencilView;
+    ID3D11RenderTargetView* m_pRenderTarget;
+    ID3D11DepthStencilView* m_pDepthStencilView;
 
     // Constant buffer
-    Microsoft::WRL::ComPtr<ID3D11Buffer> perPanelBuffer;
+    Microsoft::WRL::ComPtr<ID3D11Buffer> m_PerPanelBuffer;
 
     /* Samplers */
-    ID3D11SamplerState *const* aniSampler;
+    ID3D11SamplerState *const* m_ppAniSampler;
 };

--- a/GameProject/Engine/Utils/ECSUtils.hpp
+++ b/GameProject/Engine/Utils/ECSUtils.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <typeindex>
+
+#define TID(type) std::type_index(typeid(type))

--- a/GameProject/Game/Level/Tube.hpp
+++ b/GameProject/Game/Level/Tube.hpp
@@ -22,25 +22,28 @@ public:
     TubeHandler(ECSCore* pECS, ID3D11Device* device);
     ~TubeHandler();
 
+    virtual bool init() override;
+
     Model* createTube(const std::vector<DirectX::XMFLOAT3>& sectionPoints, const float radius, const unsigned faces);
 
     const std::vector<DirectX::XMFLOAT3>& getTubeSections() const;
     float getTubeRadius() const;
 
 private:
-    TextureLoader* textureLoader;
-    ID3D11Device* device;
-
-    std::vector<DirectX::XMFLOAT3> tubeSections;
-    std::vector<Model> tubes;
-    float tubeRadius;
-
     // Populate tube sections with enough points to create smooth curves and to avoid stretching textures. The resulting points are stored in tubePoints.
     void createSections(const std::vector<DirectX::XMFLOAT3>& sectionPoints, std::vector<TubePoint>& tubePoints, const float radius);
 
-    // Gets the forward vector of a point at T0 pointing at T1 in a catmull-rom curve
-    DirectX::XMFLOAT3 getPointForward(DirectX::XMVECTOR P[], DirectX::XMVECTOR& pointPos, float T0, float T1);
-
     // Creates a point in the tube. sectionPoints contains the sparse control points, and tubePoints contains the densely packed points.
     void createTubePoint(const std::vector<DirectX::XMFLOAT3>& sectionPoints, std::vector<TubePoint>& tubePoints, size_t pointIdx, float T);
+
+private:
+    TextureLoader* m_pTextureLoader;
+    ID3D11Device* m_pDevice;
+
+    std::vector<DirectX::XMFLOAT3> m_TubeSections;
+    std::vector<Model> m_Tubes;
+    float m_TubeRadius;
+
+    // Gets the forward vector of a point at T0 pointing at T1 in a catmull-rom curve
+    DirectX::XMFLOAT3 getPointForward(DirectX::XMVECTOR P[], DirectX::XMVECTOR& pointPos, float T0, float T1);
 };

--- a/GameProject/Game/LightSpinner.cpp
+++ b/GameProject/Game/LightSpinner.cpp
@@ -1,35 +1,39 @@
 #include "LightSpinner.hpp"
 
 #include <Engine/Rendering/Components/PointLight.hpp>
+#include <Engine/Utils/ECSUtils.hpp>
 
 LightSpinner::LightSpinner(ECSCore* pECS)
     :System(pECS)
 {
-    std::type_index tid_lightHandler = std::type_index(typeid(LightHandler));
-    this->lightHandler = static_cast<LightHandler*>(getComponentHandler(tid_lightHandler));
-
     SystemRegistration sysReg = {
     {
-        {{{RW, tid_pointLight}}, &lights}
+        {{{RW, tid_pointLight}}, &m_Lights}
     },
     this};
 
-    this->subscribeToComponents(&sysReg);
-    this->registerUpdate(&sysReg);
+    subscribeToComponents(sysReg);
+    registerUpdate(&sysReg);
 }
 
 LightSpinner::~LightSpinner()
 {}
 
+bool LightSpinner::init()
+{
+    m_pLightHandler = static_cast<LightHandler*>(getComponentHandler(TID(LightHandler)));
+    return m_pLightHandler;
+}
+
 void LightSpinner::update(float dt)
 {
-    size_t lightCount = lights.size();
+    size_t lightCount = m_Lights.size();
 
     const float anglePerSec = DirectX::XM_PIDIV4;
     DirectX::XMVECTOR position;
 
     for (size_t i = 0; i < lightCount; i += 1) {
-        PointLight& light = lightHandler->pointLights.indexID(lights[i]);
+        PointLight& light = m_pLightHandler->pointLights.indexID(m_Lights[i]);
 
         position = DirectX::XMLoadFloat3(&light.position);
 

--- a/GameProject/Game/LightSpinner.hpp
+++ b/GameProject/Game/LightSpinner.hpp
@@ -10,9 +10,11 @@ public:
     LightSpinner(ECSCore* pECS);
     ~LightSpinner();
 
+    virtual bool init() override;
+
     void update(float dt);
 
 private:
-    LightHandler* lightHandler;
-    IDVector<Entity> lights;
+    LightHandler* m_pLightHandler;
+    IDVector<Entity> m_Lights;
 };

--- a/GameProject/Game/Racer/Components/TrackPosition.cpp
+++ b/GameProject/Game/Racer/Components/TrackPosition.cpp
@@ -1,17 +1,24 @@
 #include "TrackPosition.hpp"
 
 TrackPositionHandler::TrackPositionHandler(ECSCore* pECS)
-    :ComponentHandler({tid_trackPosition}, pECS, std::type_index(typeid(TrackPositionHandler)))
+    :ComponentHandler({tid_trackPosition}, pECS, TID(TrackPositionHandler))
 {
-    std::vector<ComponentRegistration> compRegs = {
+    ComponentHandlerRegistration handlerReg = {};
+    handlerReg.pComponentHandler = this;
+    handlerReg.ComponentRegistrations = {
         {tid_trackPosition, &trackPositions}
     };
 
-    this->registerHandler(&compRegs);
+    this->registerHandler(handlerReg);
 }
 
 TrackPositionHandler::~TrackPositionHandler()
 {}
+
+bool TrackPositionHandler::init()
+{
+    return true;
+}
 
 void TrackPositionHandler::createTrackPosition(Entity entity)
 {

--- a/GameProject/Game/Racer/Components/TrackPosition.hpp
+++ b/GameProject/Game/Racer/Components/TrackPosition.hpp
@@ -2,6 +2,7 @@
 
 #include <Engine/ECS/ComponentHandler.hpp>
 #include <Engine/Utils/IDVector.hpp>
+#include <Engine/Utils/ECSUtils.hpp>
 #include <typeindex>
 
 struct TrackPosition {
@@ -11,13 +12,15 @@ struct TrackPosition {
     float distanceFromCenter;
 };
 
-const std::type_index tid_trackPosition = std::type_index(typeid(TrackPosition));
+const std::type_index tid_trackPosition = TID(TrackPosition);
 
 class TrackPositionHandler : public ComponentHandler
 {
 public:
     TrackPositionHandler(ECSCore* pECS);
     ~TrackPositionHandler();
+
+    virtual bool init() override;
 
     void createTrackPosition(Entity entity);
 

--- a/GameProject/Game/Racer/Systems/RacerMover.hpp
+++ b/GameProject/Game/Racer/Systems/RacerMover.hpp
@@ -9,14 +9,18 @@ class TransformHandler;
 class TubeHandler;
 
 const float racerSpeed = 3.0f;
+
 // Radians per second
 const float rotationSpeed = DirectX::XM_PIDIV2 * 0.8f;
+
 // Racers' minimum distance to the tube's edge or center
 const float minEdgeDistance = 0.3f;
 const float minCenterDistance = 0.05f;
+
 // Speed at which a racer moves towards or away from the center
 const float centerMoveSpeed = 1.0f;
-// Racers' starting distance from the tube's center, where 0 is nearest allowed distance, and 1 is the furthest
+
+// Racers' starting distance from the tube's center, [0, 1]
 const float startingCenterDistance = 0.5f;
 
 class RacerMover : public System
@@ -25,16 +29,18 @@ public:
     RacerMover(ECSCore* pECS);
     ~RacerMover();
 
+    virtual bool init() override;
+
     void update(float dt);
 
 private:
     void racerAdded(Entity entity);
 
-    IDVector<Entity> racers;
+    IDVector<Entity> m_Racers;
 
-    TransformHandler* transformHandler;
-    TrackPositionHandler* trackPositionHandler;
-    TubeHandler* tubeHandler;
+    TransformHandler* m_pTransformHandler;
+    TrackPositionHandler* m_pTrackPositionHandler;
+    TubeHandler* m_pTubeHandler;
 
-    DirectX::Keyboard::State* keyboardState;
+    DirectX::Keyboard::State* m_pKeyboardState;
 };

--- a/GameProject/Game/States/MainMenu.cpp
+++ b/GameProject/Game/States/MainMenu.cpp
@@ -6,6 +6,7 @@
 #include <Engine/Rendering/AssetLoaders/TextureLoader.hpp>
 #include <Engine/Rendering/Text/TextRenderer.hpp>
 #include <Engine/UI/Panel.hpp>
+#include <Engine/Utils/ECSUtils.hpp>
 #include <Engine/Utils/Logger.hpp>
 #include <Game/States/GameSession.hpp>
 
@@ -13,19 +14,14 @@ MainMenu::MainMenu(StateManager* stateManager, ECSCore* pECS, ID3D11Device* devi
     :State(stateManager, pECS, STATE_TRANSITION::PUSH),
     device(device)
 {
-    std::type_index tid_inputHandler = std::type_index(typeid(InputHandler));
-
-    this->inputHandler = static_cast<InputHandler*>(pECS->getSystemSubscriber()->getComponentHandler(tid_inputHandler));
+    this->inputHandler = static_cast<InputHandler*>(pECS->getSystemSubscriber()->getComponentHandler(TID(InputHandler)));
     inputHandler->setMouseMode(DirectX::Mouse::Mode::MODE_ABSOLUTE);
     inputHandler->setMouseVisibility(true);
     this->keyboardState = inputHandler->getKeyboardState();
 
-    std::type_index tid_uiHandler = std::type_index(typeid(UIHandler));
-    UIHandler* uiHandler = static_cast<UIHandler*>(pECS->getSystemSubscriber()->getComponentHandler(tid_uiHandler));
-    std::type_index tid_textRenderer = std::type_index(typeid(TextRenderer));
-    TextRenderer* pTextRenderer = static_cast<TextRenderer*>(pECS->getSystemSubscriber()->getComponentHandler(tid_textRenderer));
-    std::type_index tid_textureLoader = std::type_index(typeid(TextureLoader));
-    TextureLoader* pTextureLoader = static_cast<TextureLoader*>(pECS->getSystemSubscriber()->getComponentHandler(tid_textureLoader));
+    UIHandler* uiHandler            = static_cast<UIHandler*>(pECS->getSystemSubscriber()->getComponentHandler(TID(UIHandler)));
+    TextRenderer* pTextRenderer     = static_cast<TextRenderer*>(pECS->getSystemSubscriber()->getComponentHandler(TID(TextRenderer)));
+    TextureLoader* pTextureLoader   = static_cast<TextureLoader*>(pECS->getSystemSubscriber()->getComponentHandler(TID(TextureLoader)));
 
     // Create UI panel
     uiEntity = m_pECS->createEntity();
@@ -38,10 +34,10 @@ MainMenu::MainMenu(StateManager* stateManager, ECSCore* pECS, ID3D11Device* devi
     };
 
     TextureAttachmentInfo txAttachmentInfos[2];
-    txAttachmentInfos[0].sizeSetting = TX_SIZE_STRETCH;
-    txAttachmentInfos[1].horizontalAlignment = TX_HORIZONTAL_ALIGNMENT_CENTER;
-    txAttachmentInfos[1].verticalAlignment = TX_VERTICAL_ALIGNMENT_CENTER;
-    txAttachmentInfos[1].sizeSetting = TX_SIZE_CLIENT_RESOLUTION_DEPENDENT;
+    txAttachmentInfos[0].sizeSetting            = TX_SIZE_STRETCH;
+    txAttachmentInfos[1].horizontalAlignment    = TX_HORIZONTAL_ALIGNMENT_CENTER;
+    txAttachmentInfos[1].verticalAlignment      = TX_VERTICAL_ALIGNMENT_CENTER;
+    txAttachmentInfos[1].sizeSetting            = TX_SIZE_CLIENT_RESOLUTION_DEPENDENT;
 
     uiHandler->attachTextures(uiEntity, txAttachmentInfos, panelTextures, ARRAYSIZE(panelTextures));
 

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -235,6 +235,7 @@
     <ClCompile Include="..\include\DirectXTK\pch.cpp" />
     <ClCompile Include="..\include\DirectXTK\WICTextureLoader.cpp" />
     <ClCompile Include="Engine\ECS\ComponentHandler.cpp" />
+    <ClCompile Include="Engine\ECS\ECSBooter.cpp" />
     <ClCompile Include="Engine\ECS\ECSCore.cpp" />
     <ClCompile Include="Engine\ECS\EntityRegistry.cpp" />
     <ClCompile Include="Engine\ECS\System.cpp" />
@@ -306,6 +307,7 @@
     <ClInclude Include="..\include\DirectXTK\PlatformHelpers.h" />
     <ClInclude Include="..\include\DirectXTK\WICTextureLoader.h" />
     <ClInclude Include="Engine\ECS\ComponentHandler.hpp" />
+    <ClInclude Include="Engine\ECS\ECSBooter.hpp" />
     <ClInclude Include="Engine\ECS\ECSCore.hpp" />
     <ClInclude Include="Engine\ECS\Entity.hpp" />
     <ClInclude Include="Engine\ECS\EntityRegistry.hpp" />
@@ -336,6 +338,7 @@
     <ClInclude Include="Engine\UI\Panel.hpp" />
     <ClInclude Include="Engine\UI\UIRenderer.hpp" />
     <ClInclude Include="Engine\Utils\DirectXUtils.hpp" />
+    <ClInclude Include="Engine\Utils\ECSUtils.hpp" />
     <ClInclude Include="Engine\Utils\IDContainer.hpp" />
     <ClInclude Include="Engine\Utils\IDGenerator.hpp" />
     <ClInclude Include="Engine\Utils\IDVector.hpp" />


### PR DESCRIPTION
Component handlers are sometimes dependent of other component handlers, and systems are almost always dependent on component handlers. This made initializing these classes difficult, as they had to be initialized in a certain order.

The ECS Booter solves this issue by registering registration requests, and resolving them all at once, by figuring out the correct order in which to do so.

Closes #24 