### PR TITLE
Generalize component subscriptions

### DIFF
--- a/GameProject/Engine/Audio/SoundPlayer.cpp
+++ b/GameProject/Engine/Audio/SoundPlayer.cpp
@@ -7,13 +7,13 @@ SoundPlayer::SoundPlayer(ECSCore* pECS)
     m_pSoundHandler(nullptr)
 {
     SystemRegistration sysReg = {};
-    sysReg.system = this;
-    sysReg.subReqs = {
+    sysReg.pSystem = this;
+    sysReg.SubscriptionRequests = {
         {{{R, tid_sound}}, &m_Sounds}
     };
 
     subscribeToComponents(sysReg);
-    registerUpdate(&sysReg);
+    registerUpdate(sysReg);
 }
 
 SoundPlayer::~SoundPlayer()

--- a/GameProject/Engine/ECS/ComponentHandler.cpp
+++ b/GameProject/Engine/ECS/ComponentHandler.cpp
@@ -10,7 +10,7 @@ ComponentHandler::ComponentHandler(std::vector<std::type_index> handledTypes, EC
 
 ComponentHandler::~ComponentHandler()
 {
-    m_pECS->getSystemSubscriber()->deregisterComponentHandler(this);
+    m_pECS->getComponentSubscriber()->deregisterComponentHandler(this);
 }
 
 void ComponentHandler::registerHandler(const ComponentHandlerRegistration& handlerRegistration)

--- a/GameProject/Engine/ECS/ComponentSubscriber.cpp
+++ b/GameProject/Engine/ECS/ComponentSubscriber.cpp
@@ -1,18 +1,18 @@
-#include "SystemSubscriber.hpp"
+#include "ComponentSubscriber.hpp"
 
 #include <Engine/ECS/ComponentHandler.hpp>
 #include <Engine/ECS/System.hpp>
 #include <Engine/Utils/Logger.hpp>
 
-SystemSubscriber::SystemSubscriber(EntityRegistry* pEntityRegistry)
+ComponentSubscriber::ComponentSubscriber(EntityRegistry* pEntityRegistry)
     :m_pEntityRegistry(pEntityRegistry)
 {}
 
-SystemSubscriber::~SystemSubscriber()
+ComponentSubscriber::~ComponentSubscriber()
 {}
 
 
-void SystemSubscriber::registerComponentHandler(const ComponentHandlerRegistration& componentHandlerRegistration)
+void ComponentSubscriber::registerComponentHandler(const ComponentHandlerRegistration& componentHandlerRegistration)
 {
     ComponentHandler* pComponentHandler = componentHandlerRegistration.pComponentHandler;
     std::type_index tidHandler = pComponentHandler->getHandlerType();
@@ -32,7 +32,7 @@ void SystemSubscriber::registerComponentHandler(const ComponentHandlerRegistrati
     }
 }
 
-void SystemSubscriber::deregisterComponentHandler(ComponentHandler* handler)
+void ComponentSubscriber::deregisterComponentHandler(ComponentHandler* handler)
 {
     const std::vector<std::type_index>& componentTypes = handler->getHandledTypes();
 
@@ -63,7 +63,7 @@ void SystemSubscriber::deregisterComponentHandler(ComponentHandler* handler)
     componentHandlers.erase(handlerItr);
 }
 
-ComponentHandler* SystemSubscriber::getComponentHandler(const std::type_index& handlerType)
+ComponentHandler* ComponentSubscriber::getComponentHandler(const std::type_index& handlerType)
 {
     auto itr = componentHandlers.find(handlerType);
 
@@ -75,7 +75,7 @@ ComponentHandler* SystemSubscriber::getComponentHandler(const std::type_index& h
     return itr->second;
 }
 
-size_t SystemSubscriber::subscribeToComponents(const std::vector<ComponentSubscriptionRequest>& subscriptionRequests)
+size_t ComponentSubscriber::subscribeToComponents(const std::vector<ComponentSubscriptionRequest>& subscriptionRequests)
 {
     // Create subscriptions from the subscription requests by finding the desired component containers
     std::vector<ComponentSubscriptions> subscriptions;
@@ -144,7 +144,7 @@ size_t SystemSubscriber::subscribeToComponents(const std::vector<ComponentSubscr
     return subID;
 }
 
-void SystemSubscriber::unsubscribeFromComponents(size_t subscriptionID, std::vector<std::type_index>& componentTypes)
+void ComponentSubscriber::unsubscribeFromComponents(size_t subscriptionID, std::vector<std::type_index>& componentTypes)
 {
     if (subscriptionStorage.hasElement(subscriptionID) == false) {
         LOG_WARNING("Attempted to deregistered an unregistered system, ID: %d", subscriptionID);
@@ -185,7 +185,7 @@ void SystemSubscriber::unsubscribeFromComponents(size_t subscriptionID, std::vec
     systemIdGen.popID(subscriptionID);
 }
 
-void SystemSubscriber::newComponent(Entity entityID, std::type_index componentType)
+void ComponentSubscriber::newComponent(Entity entityID, std::type_index componentType)
 {
     // Get all subscriptions for the component type by iterating through the unordered_map bucket
     auto subBucketItr = componentSubscriptions.find(componentType);
@@ -206,7 +206,7 @@ void SystemSubscriber::newComponent(Entity entityID, std::type_index componentTy
     }
 }
 
-void SystemSubscriber::removedComponent(Entity entityID, std::type_index componentType)
+void ComponentSubscriber::removedComponent(Entity entityID, std::type_index componentType)
 {
     // Get all subscriptions for the component type by iterating through the unordered_map bucket
     auto subBucketItr = componentSubscriptions.find(componentType);

--- a/GameProject/Engine/ECS/ComponentSubscriber.hpp
+++ b/GameProject/Engine/ECS/ComponentSubscriber.hpp
@@ -37,11 +37,11 @@ struct ComponentStorage {
     std::function<void(Entity)> m_ComponentDestructor;
 };
 
-class SystemSubscriber
+class ComponentSubscriber
 {
 public:
-    SystemSubscriber(EntityRegistry* pEntityRegistry);
-    ~SystemSubscriber();
+    ComponentSubscriber(EntityRegistry* pEntityRegistry);
+    ~ComponentSubscriber();
 
     void registerComponentHandler(const ComponentHandlerRegistration& componentHandlerRegistration);
     void deregisterComponentHandler(ComponentHandler* handler);

--- a/GameProject/Engine/ECS/ECSBooter.cpp
+++ b/GameProject/Engine/ECS/ECSBooter.cpp
@@ -96,13 +96,16 @@ void ECSBooter::bootHandlers()
 
 void ECSBooter::bootSystems()
 {
-    SystemSubscriber* pSystemSubscriber = m_pECS->getSystemSubscriber();
+    SystemSubscriber* pComponentSubscriber = m_pECS->getSystemSubscriber();
 
     for (const SystemRegistration& systemReg : m_SystemsToRegister) {
-        if (!systemReg.system->init()) {
-            LOG_ERROR("Failed to initialize system, ID: %d", systemReg.system->ID);
+        System* pSystem = systemReg.pSystem;
+
+        if (!systemReg.pSystem->init()) {
+            LOG_ERROR("Failed to initialize system");
         } else {
-            pSystemSubscriber->registerSystem(systemReg);
+            size_t subscriptionID = pComponentSubscriber->subscribeToComponents(systemReg.SubscriptionRequests);
+            pSystem->setComponentSubscriptionID(subscriptionID);
         }
     }
 }

--- a/GameProject/Engine/ECS/ECSBooter.cpp
+++ b/GameProject/Engine/ECS/ECSBooter.cpp
@@ -96,7 +96,7 @@ void ECSBooter::bootHandlers()
 
 void ECSBooter::bootSystems()
 {
-    SystemSubscriber* pComponentSubscriber = m_pECS->getSystemSubscriber();
+    ComponentSubscriber* pComponentSubscriber = m_pECS->getComponentSubscriber();
 
     for (const SystemRegistration& systemReg : m_SystemsToRegister) {
         System* pSystem = systemReg.pSystem;
@@ -139,7 +139,7 @@ void ECSBooter::finalizeHandlerBootDependencies()
                 bootInfo.dependencyMapIterators.push_back(dependencyItr);
             } else {
                 // The dependency is not enqueued for bootup, it might already be booted
-                if (!m_pECS->getSystemSubscriber()->getComponentHandler(dependencyTID)) {
+                if (!m_pECS->getComponentSubscriber()->getComponentHandler(dependencyTID)) {
                     LOG_ERROR("Cannot boot handler: %s, missing dependency: %s", bootInfo.handlerRegistration->pComponentHandler->getHandlerType().name(), dependencyTID.name());
                     hasDependencies = false;
                     break;
@@ -163,6 +163,6 @@ void ECSBooter::bootHandler(ComponentHandlerBootInfo& bootInfo)
     if (!bootInfo.handlerRegistration->pComponentHandler->init()) {
         LOG_ERROR("Failed to initialize component handler: %s", bootInfo.handlerRegistration->pComponentHandler->getHandlerType().name());
     } else {
-        m_pECS->getSystemSubscriber()->registerComponentHandler(*bootInfo.handlerRegistration);
+        m_pECS->getComponentSubscriber()->registerComponentHandler(*bootInfo.handlerRegistration);
     }
 }

--- a/GameProject/Engine/ECS/ECSCore.hpp
+++ b/GameProject/Engine/ECS/ECSCore.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <Engine/ECS/ComponentHandler.hpp>
+#include <Engine/ECS/ComponentSubscriber.hpp>
 #include <Engine/ECS/ECSBooter.hpp>
 #include <Engine/ECS/EntityRegistry.hpp>
 #include <Engine/ECS/System.hpp>
-#include <Engine/ECS/SystemSubscriber.hpp>
 #include <Engine/ECS/SystemUpdater.hpp>
 #include <Engine/Utils/IDGenerator.hpp>
 
@@ -32,7 +32,7 @@ public:
     void deleteEntityDelayed(Entity entity);
     void performMaintenance();
 
-    SystemSubscriber* getSystemSubscriber() { return &m_SystemSubscriber; }
+    ComponentSubscriber* getComponentSubscriber() { return &m_ComponentSubscriber; }
     SystemUpdater* getSystemUpdater() { return &m_SystemUpdater; }
     EntityRegistry* getEntityRegistry() { return &m_EntityRegistry; }
 
@@ -46,7 +46,7 @@ public:
 
 private:
     EntityRegistry m_EntityRegistry;
-    SystemSubscriber m_SystemSubscriber;
+    ComponentSubscriber m_ComponentSubscriber;
     SystemUpdater m_SystemUpdater;
     ECSBooter m_ECSBooter;
 

--- a/GameProject/Engine/ECS/Renderer.cpp
+++ b/GameProject/Engine/ECS/Renderer.cpp
@@ -1,0 +1,27 @@
+#include "Renderer.hpp"
+
+#include <Engine/Utils/DirectXUtils.hpp>
+#include <Engine/Utils/Logger.hpp>
+
+Renderer::Renderer(ECSCore* pECS)
+    :m_pECS(pECS),
+    m_pDeferredContext(nullptr)
+{}
+
+Renderer::~Renderer()
+{
+    if (m_pDeferredContext) {
+        m_pDeferredContext->Release();
+    }
+}
+
+bool Renderer::init(ID3D11Device* pDevice)
+{
+    HRESULT hr = pDevice->CreateDeferredContext(0, &m_pDeferredContext);
+    if (FAILED(hr)) {
+        LOG_ERROR("Failed to create deferred context: %s", hresultToString(hr).c_str());
+        return false;
+    }
+
+    return true;
+}

--- a/GameProject/Engine/ECS/Renderer.hpp
+++ b/GameProject/Engine/ECS/Renderer.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Engine/ECS/ECSCore.hpp>
+
+#include <d3d11.h>
+
+class Renderer
+{
+public:
+    Renderer(ECSCore* pECS);
+    ~Renderer();
+
+    bool init(ID3D11Device* pDevice);
+
+    virtual void recordCommands() = 0;
+
+    void beginFrame();
+    void endFrame();
+    void executeCommands();
+
+private:
+    ECSCore* m_pECS;
+
+    // Deferred context for recording commands
+    ID3D11DeviceContext* m_pDeferredContext;
+};

--- a/GameProject/Engine/ECS/System.cpp
+++ b/GameProject/Engine/ECS/System.cpp
@@ -9,7 +9,7 @@ System::System(ECSCore* pECS)
 
 System::~System()
 {
-    m_pECS->getSystemSubscriber()->deregisterSystem(this, componentTypes);
+    m_pECS->getSystemSubscriber()->unsubscribeFromComponents(m_ComponentSubscriptionID, m_ComponentSubscriptionTypes);
 }
 
 void System::subscribeToComponents(const SystemRegistration& sysReg)
@@ -17,14 +17,9 @@ void System::subscribeToComponents(const SystemRegistration& sysReg)
     m_pECS->enqueueSystemRegistration(sysReg);
 }
 
-void System::registerUpdate(SystemRegistration* sysReg)
+void System::registerUpdate(const SystemRegistration& sysReg)
 {
     m_pECS->getSystemUpdater()->registerSystem(sysReg);
-}
-
-void System::unsubscribeFromComponents(std::vector<std::type_index> unsubTypes)
-{
-    m_pECS->getSystemSubscriber()->deregisterSystem(this, unsubTypes);
 }
 
 ComponentHandler* System::getComponentHandler(const std::type_index& handlerType)

--- a/GameProject/Engine/ECS/System.cpp
+++ b/GameProject/Engine/ECS/System.cpp
@@ -1,7 +1,7 @@
 #include "System.hpp"
 
 #include <Engine/ECS/ECSCore.hpp>
-#include <Engine/ECS/SystemSubscriber.hpp>
+#include <Engine/ECS/ComponentSubscriber.hpp>
 
 System::System(ECSCore* pECS)
     :m_pECS(pECS)
@@ -9,7 +9,7 @@ System::System(ECSCore* pECS)
 
 System::~System()
 {
-    m_pECS->getSystemSubscriber()->unsubscribeFromComponents(m_ComponentSubscriptionID, m_ComponentSubscriptionTypes);
+    m_pECS->getComponentSubscriber()->unsubscribeFromComponents(m_ComponentSubscriptionID, m_ComponentSubscriptionTypes);
 }
 
 void System::subscribeToComponents(const SystemRegistration& sysReg)
@@ -24,5 +24,5 @@ void System::registerUpdate(const SystemRegistration& sysReg)
 
 ComponentHandler* System::getComponentHandler(const std::type_index& handlerType)
 {
-    return m_pECS->getSystemSubscriber()->getComponentHandler(handlerType);
+    return m_pECS->getComponentSubscriber()->getComponentHandler(handlerType);
 }

--- a/GameProject/Engine/ECS/System.hpp
+++ b/GameProject/Engine/ECS/System.hpp
@@ -17,7 +17,7 @@ struct ComponentUpdateReg {
 };
 
 // A request for a system to subscribe to one or more component types
-struct ComponentSubReq {
+struct ComponentSubscriptionRequest {
     std::vector<ComponentUpdateReg> componentTypes;
     IDVector<Entity>* subscriber;
     // Optional: Called after an entity was added due to the subscription
@@ -27,14 +27,14 @@ struct ComponentSubReq {
 class System;
 
 struct SystemRegistration {
-    std::vector<ComponentSubReq> subReqs;
-    System* system;
+    std::vector<ComponentSubscriptionRequest> SubscriptionRequests;
+    System* pSystem;
 };
 
 class ComponentHandler;
 class ECSCore;
 class SystemSubscriber;
-struct ComponentSubReq;
+struct ComponentSubscriptionRequest;
 
 /*
     A system stores pointers to component storages and processes the components each frame
@@ -53,17 +53,22 @@ public:
 
     virtual void update(float dt) = 0;
 
-    size_t ID;
+    inline size_t getSystemID() const { return m_SystemID; }
+    void setSystemID(size_t systemID) { m_SystemID = systemID; }
+
+    void setComponentSubscriptionID(size_t ID) { m_ComponentSubscriptionID = ID; }
 
 protected:
     void subscribeToComponents(const SystemRegistration& sysReg);
-    void registerUpdate(SystemRegistration* sysReg);
+    void registerUpdate(const SystemRegistration& sysReg);
 
-    void unsubscribeFromComponents(std::vector<std::type_index> unsubTypes);
     ComponentHandler* getComponentHandler(const std::type_index& handlerType);
 
-    std::vector<std::type_index> componentTypes;
+    std::vector<std::type_index> m_ComponentSubscriptionTypes;
 
 private:
     ECSCore* m_pECS;
+
+    size_t m_ComponentSubscriptionID;
+    size_t m_SystemID;
 };

--- a/GameProject/Engine/ECS/System.hpp
+++ b/GameProject/Engine/ECS/System.hpp
@@ -33,7 +33,7 @@ struct SystemRegistration {
 
 class ComponentHandler;
 class ECSCore;
-class SystemSubscriber;
+class ComponentSubscriber;
 struct ComponentSubscriptionRequest;
 
 /*

--- a/GameProject/Engine/ECS/SystemSubscriber.cpp
+++ b/GameProject/Engine/ECS/SystemSubscriber.cpp
@@ -75,13 +75,13 @@ ComponentHandler* SystemSubscriber::getComponentHandler(const std::type_index& h
     return itr->second;
 }
 
-void SystemSubscriber::registerSystem(const SystemRegistration& sysReg)
+size_t SystemSubscriber::subscribeToComponents(const std::vector<ComponentSubscriptionRequest>& subscriptionRequests)
 {
     // Create subscriptions from the subscription requests by finding the desired component containers
     std::vector<ComponentSubscriptions> subscriptions;
-    subscriptions.reserve(sysReg.subReqs.size());
+    subscriptions.reserve(subscriptionRequests.size());
 
-    for (const ComponentSubReq& subReq : sysReg.subReqs) {
+    for (const ComponentSubscriptionRequest& subReq : subscriptionRequests) {
         const std::vector<ComponentUpdateReg>& componentRegs = subReq.componentTypes;
 
         ComponentSubscriptions newSub;
@@ -94,8 +94,8 @@ void SystemSubscriber::registerSystem(const SystemRegistration& sysReg)
             auto queryItr = m_ComponentStorage.find(componentReg.tid);
 
             if (queryItr == m_ComponentStorage.end()) {
-                LOG_WARNING("Attempted to subscribe to unregistered component type: %s, hash: %d", componentReg.tid.name(), componentReg.tid.hash_code());
-                return;
+                LOG_ERROR("Attempted to subscribe to unregistered component type: %s, hash: %d", componentReg.tid.name(), componentReg.tid.hash_code());
+                return 0;
             }
 
             newSub.componentTypes.push_back(componentReg.tid);
@@ -104,23 +104,17 @@ void SystemSubscriber::registerSystem(const SystemRegistration& sysReg)
         subscriptions.push_back(newSub);
     }
 
-    if (subscriptions.size() == 0) {
-        LOG_WARNING("No subscriptions were able to be made during a system registration");
-        return;
-    }
-
-    size_t sysID = systemIdGen.genID();
-    sysReg.system->ID = sysID;
-    this->subscriptionStorage.push_back(subscriptions, sysID);
+    size_t subID = systemIdGen.genID();
+    this->subscriptionStorage.push_back(subscriptions, subID);
 
     // Map each component type to its subscriptions
-    const std::vector<ComponentSubscriptions>& subs = subscriptionStorage.indexID(sysID);
+    const std::vector<ComponentSubscriptions>& subs = subscriptionStorage.indexID(subID);
 
-    for (size_t i = 0; i < subs.size(); i += 1) {
-        const std::vector<std::type_index>& componentTypes = subs[i].componentTypes;
+    for (size_t subscriptionNr = 0; subscriptionNr < subs.size(); subscriptionNr += 1) {
+        const std::vector<std::type_index>& componentTypes = subs[subscriptionNr].componentTypes;
 
-        for (size_t j = 0; j < componentTypes.size(); j += 1) {
-            componentSubscriptions.insert({componentTypes[j], {sysID, i}});
+        for (const std::type_index& componentType : componentTypes) {
+            componentSubscriptions.insert({componentType, {subID, subscriptionNr}});
         }
     }
 
@@ -146,17 +140,19 @@ void SystemSubscriber::registerSystem(const SystemRegistration& sysReg)
             }
         }
     }
+
+    return subID;
 }
 
-void SystemSubscriber::deregisterSystem(System* system, std::vector<std::type_index>& componentTypes)
+void SystemSubscriber::unsubscribeFromComponents(size_t subscriptionID, std::vector<std::type_index>& componentTypes)
 {
-    if (subscriptionStorage.hasElement(system->ID) == false) {
-        LOG_WARNING("Attempted to deregistered an unregistered system, ID: %d", system->ID);
+    if (subscriptionStorage.hasElement(subscriptionID) == false) {
+        LOG_WARNING("Attempted to deregistered an unregistered system, ID: %d", subscriptionID);
         return;
     }
 
     // Use the subscriptions to find and delete component subscriptions
-    std::vector<ComponentSubscriptions>& subscriptions = subscriptionStorage.indexID(system->ID);
+    std::vector<ComponentSubscriptions>& subscriptions = subscriptionStorage.indexID(subscriptionID);
 
     for (const ComponentSubscriptions& subscription : subscriptions) {
         const std::vector<std::type_index>& componentTypes = subscription.componentTypes;
@@ -172,7 +168,7 @@ void SystemSubscriber::deregisterSystem(System* system, std::vector<std::type_in
 
             // Find the subscription and delete it
             while (subBucketItr != componentSubscriptions.end() && subBucketItr->first == componentType) {
-                if (subBucketItr->second.systemID == system->ID) {
+                if (subBucketItr->second.systemID == subscriptionID) {
                     componentSubscriptions.erase(subBucketItr);
                     break;
                 }
@@ -183,10 +179,10 @@ void SystemSubscriber::deregisterSystem(System* system, std::vector<std::type_in
     }
 
     // All component->subscription mappings have been deleted
-    subscriptionStorage.pop(system->ID);
+    subscriptionStorage.pop(subscriptionID);
 
     // Recycle system iD
-    systemIdGen.popID(system->ID);
+    systemIdGen.popID(subscriptionID);
 }
 
 void SystemSubscriber::newComponent(Entity entityID, std::type_index componentType)
@@ -198,16 +194,7 @@ void SystemSubscriber::newComponent(Entity entityID, std::type_index componentTy
         // Use indices stored in the component type -> component storage mapping to get the component subscription
         ComponentSubscriptions& sysSub = subscriptionStorage.indexID(subBucketItr->second.systemID)[subBucketItr->second.subIdx];
 
-        // TODO: Remove? Is it even possible for a system to have acquired an entity ID, and then have its subscription triggered again?
-        if (sysSub.subscriber->hasElement(entityID)) {
-            subBucketItr++;
-            continue;
-        }
-
-        // Whether or not the entity has all the subscribed component types
-        bool triggerSub = m_pEntityRegistry->entityHasTypes(entityID, sysSub.componentTypes);
-
-        if (triggerSub) {
+        if (m_pEntityRegistry->entityHasTypes(entityID, sysSub.componentTypes)) {
             sysSub.subscriber->push_back(entityID, entityID);
 
             if (sysSub.onEntityAdded != nullptr) {

--- a/GameProject/Engine/ECS/SystemSubscriber.hpp
+++ b/GameProject/Engine/ECS/SystemSubscriber.hpp
@@ -47,8 +47,9 @@ public:
     void deregisterComponentHandler(ComponentHandler* handler);
     ComponentHandler* getComponentHandler(const std::type_index& handlerType);
 
-    void registerSystem(const SystemRegistration& sysReg);
-    void deregisterSystem(System* system, std::vector<std::type_index>& componentTypes);
+    // Returns a subscription ID
+    size_t subscribeToComponents(const std::vector<ComponentSubscriptionRequest>& subscriptionRequests);
+    void unsubscribeFromComponents(size_t subscriptionID, std::vector<std::type_index>& componentTypes);
 
     // Notifies subscribed systems that a new component has been made
     void newComponent(Entity entityID, std::type_index componentType);

--- a/GameProject/Engine/ECS/SystemUpdater.hpp
+++ b/GameProject/Engine/ECS/SystemUpdater.hpp
@@ -1,16 +1,17 @@
 #pragma once
 
 // TODO: Move to config file
-// TODO: Get maximum number of threads programmatically
+// TODO: Get maximum number of threads at runtime
 #define MAX_THREADS 4
 
 #include <Engine/ECS/System.hpp>
+#include <Engine/Utils/IDGenerator.hpp>
 #include <mutex>
 #include <unordered_map>
 
 struct SystemUpdateInfo {
-    System* system;
-    std::vector<ComponentUpdateReg> components;
+    System* pSystem;
+    std::vector<ComponentUpdateReg> Components;
 };
 
 typedef std::vector<std::unordered_multimap<std::type_index, ComponentPermissions>::iterator> ProcessingSystemsIterators;
@@ -21,8 +22,8 @@ public:
     SystemUpdater();
     ~SystemUpdater();
 
-    void registerSystem(SystemRegistration* sysReg);
-    void deregisterSystem(System* system);
+    void registerSystem(const SystemRegistration& sysReg);
+    void deregisterSystem(System* pSystem);
 
     // Updates all systems with a single thread
     void updateST(float dt);
@@ -30,9 +31,11 @@ public:
     void updateMT(float dt);
 
 private:
+    IDGenerator m_SystemIDGen;
+
     // Contains pointers to systems as well as information on what components they process and with what permissions
     // so that safe multi-threading can be performed
-    IDVector<SystemUpdateInfo> updateInfos;
+    IDVector<SystemUpdateInfo> m_UpdateInfos;
 
     /* Resources for multi-threaded updates below */
     // Stores what systems have been processed during a multi-threaded pass, where an element is an index to the vector of systems
@@ -55,7 +58,7 @@ private:
      * @param processingSystemsIterators In/Out: Receives empty vector of iterators, inserts elements
      */
     void registerUpdate(const SystemUpdateInfo* systemToRegister, ProcessingSystemsIterators* processingSystemsIterators);
-    void deregisterUpdate(const ProcessingSystemsIterators* processingSystemsIterators);
+    void deregisterUpdate(const ProcessingSystemsIterators& processingSystemsIterators);
 
     // Used to time out threads unable to find updateable systems
     std::condition_variable timeoutCV;

--- a/GameProject/Engine/IGame.cpp
+++ b/GameProject/Engine/IGame.cpp
@@ -17,7 +17,7 @@ IGame::IGame(HINSTANCE hInstance)
     m_TextRenderer(&m_ECS, m_Display.getDevice(), m_Display.getDeviceContext()),
     m_UIHandler(&m_ECS, &m_Display),
     m_SoundHandler(&m_ECS),
-    m_Renderer(&m_ECS, m_Display.getDevice(), m_Display.getDeviceContext(), m_Display.getRenderTarget(), m_Display.getDepthStencilView()),
+    m_MeshRenderer(&m_ECS, m_Display.getDevice(), m_Display.getDeviceContext(), m_Display.getRenderTarget(), m_Display.getDepthStencilView()),
     m_UIRenderer(&m_ECS, m_Display.getDeviceContext(), m_Display.getDevice(), m_Display.getRenderTarget(), m_Display.getDepthStencilView()),
     m_CameraSystem(&m_ECS),
     m_ButtonSystem(&m_ECS, m_Display.getWindowWidth(), m_Display.getWindowHeight()),
@@ -26,7 +26,7 @@ IGame::IGame(HINSTANCE hInstance)
     m_ECS.performRegistrations();
 
     m_Display.showWindow();
-    m_Renderer.update(0.0f);
+    m_MeshRenderer.update(0.0f);
 }
 
 IGame::~IGame()
@@ -63,7 +63,7 @@ void IGame::run()
 
             // Render
             m_Display.clearBackBuffer();
-            m_Renderer.update(dt);
+            m_MeshRenderer.update(dt);
             m_UIRenderer.update(dt);
             m_Display.presentBackBuffer();
 

--- a/GameProject/Engine/IGame.hpp
+++ b/GameProject/Engine/IGame.hpp
@@ -11,7 +11,7 @@
 #include <Engine/Rendering/Components/Renderable.hpp>
 #include <Engine/Rendering/Components/VPMatrices.hpp>
 #include <Engine/Rendering/Display.hpp>
-#include <Engine/Rendering/Renderer.hpp>
+#include <Engine/Rendering/MeshRenderer.hpp>
 #include <Engine/Rendering/ShaderHandler.hpp>
 #include <Engine/Rendering/ShaderResourceHandler.hpp>
 #include <Engine/Rendering/Text/TextRenderer.hpp>

--- a/GameProject/Engine/IGame.hpp
+++ b/GameProject/Engine/IGame.hpp
@@ -49,7 +49,7 @@ protected:
     SoundHandler m_SoundHandler;
 
     // Systems
-    Renderer m_Renderer;
+    MeshRenderer m_MeshRenderer;
     UIRenderer m_UIRenderer;
     CameraSystem m_CameraSystem;
     ButtonSystem m_ButtonSystem;

--- a/GameProject/Engine/Rendering/AssetLoaders/ModelLoader.cpp
+++ b/GameProject/Engine/Rendering/AssetLoaders/ModelLoader.cpp
@@ -31,7 +31,7 @@ ModelLoader::~ModelLoader()
 bool ModelLoader::init()
 {
     std::type_index tid_shaderResourceHandler = TID(ShaderResourceHandler);
-    m_pShaderResourceHandler = static_cast<ShaderResourceHandler*>(m_pECS->getSystemSubscriber()->getComponentHandler(tid_shaderResourceHandler));
+    m_pShaderResourceHandler = static_cast<ShaderResourceHandler*>(m_pECS->getComponentSubscriber()->getComponentHandler(tid_shaderResourceHandler));
 
     return m_pShaderResourceHandler;
 }

--- a/GameProject/Engine/Rendering/Camera.cpp
+++ b/GameProject/Engine/Rendering/Camera.cpp
@@ -15,7 +15,7 @@ CameraSystem::CameraSystem(ECSCore* pECS)
     this};
 
     this->subscribeToComponents(sysReg);
-    this->registerUpdate(&sysReg);
+    this->registerUpdate(sysReg);
 }
 
 CameraSystem::~CameraSystem()

--- a/GameProject/Engine/Rendering/Components/Renderable.cpp
+++ b/GameProject/Engine/Rendering/Components/Renderable.cpp
@@ -1,7 +1,7 @@
 #include "Renderable.hpp"
 
 #include <Engine/ECS/ECSCore.hpp>
-#include <Engine/ECS/SystemSubscriber.hpp>
+#include <Engine/ECS/ComponentSubscriber.hpp>
 #include <Engine/Rendering/AssetLoaders/ModelLoader.hpp>
 #include <Engine/Utils/Logger.hpp>
 
@@ -23,8 +23,8 @@ RenderableHandler::RenderableHandler(ECSCore* pECS)
 
 bool RenderableHandler::init()
 {
-    m_pShaderHandler = static_cast<ShaderHandler*>(m_pECS->getSystemSubscriber()->getComponentHandler(TID(ShaderHandler)));
-    m_pModelLoader = static_cast<ModelLoader*>(m_pECS->getSystemSubscriber()->getComponentHandler(TID(ModelLoader)));
+    m_pShaderHandler = static_cast<ShaderHandler*>(m_pECS->getComponentSubscriber()->getComponentHandler(TID(ShaderHandler)));
+    m_pModelLoader = static_cast<ModelLoader*>(m_pECS->getComponentSubscriber()->getComponentHandler(TID(ModelLoader)));
 
     return m_pShaderHandler && m_pModelLoader;
 }

--- a/GameProject/Engine/Rendering/MeshRenderer.cpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.cpp
@@ -1,4 +1,4 @@
-#include "Renderer.hpp"
+#include "MeshRenderer.hpp"
 
 #include <Engine/Rendering/AssetContainers/Material.hpp>
 #include <Engine/Rendering/AssetContainers/Model.hpp>
@@ -17,7 +17,6 @@ MeshRenderer::MeshRenderer(ECSCore* pECS, ID3D11Device* pDevice, ID3D11DeviceCon
     m_pRenderTarget(pRTV),
     m_pDepthStencilView(pDSV)
 {
-
     SystemRegistration sysReg = {
     {
         {{{R, tid_renderable}, {R, tid_worldMatrix}}, &m_Renderables},

--- a/GameProject/Engine/Rendering/MeshRenderer.hpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.hpp
@@ -22,20 +22,20 @@ struct PerFrameBuffer {
     DirectX::XMFLOAT4 padding;
 };
 
-class Renderer : public System
+class MeshRenderer : public System
 {
 public:
-    Renderer(ECSCore* pECS, ID3D11Device* pDevice, ID3D11DeviceContext* pContext, ID3D11RenderTargetView* pRTV, ID3D11DepthStencilView* pDSV);
-    ~Renderer();
+    MeshRenderer(ECSCore* pECS, ID3D11Device* pDevice, ID3D11DeviceContext* pContext, ID3D11RenderTargetView* pRTV, ID3D11DepthStencilView* pDSV);
+    ~MeshRenderer();
 
     virtual bool init() override;
 
     void update(float dt);
 
 private:
-    IDVector<Entity> renderables;
-    IDVector<Entity> camera;
-    IDVector<Entity> pointLights;
+    IDVector<Entity> m_Renderables;
+    IDVector<Entity> m_Camera;
+    IDVector<Entity> m_PointLights;
 
     RenderableHandler* m_pRenderableHandler;
     TransformHandler* m_pTransformHandler;

--- a/GameProject/Engine/UI/Panel.cpp
+++ b/GameProject/Engine/UI/Panel.cpp
@@ -43,11 +43,11 @@ UIHandler::~UIHandler()
 bool UIHandler::init()
 {
     // Retrieve quad from shader resource handler
-    ShaderResourceHandler* pShaderResourceHandler = static_cast<ShaderResourceHandler*>(m_pECS->getSystemSubscriber()->getComponentHandler(TID(ShaderResourceHandler)));
+    ShaderResourceHandler* pShaderResourceHandler = static_cast<ShaderResourceHandler*>(m_pECS->getComponentSubscriber()->getComponentHandler(TID(ShaderResourceHandler)));
     m_Quad = pShaderResourceHandler->getQuarterScreenQuad();
 
     // Retrieve UI rendering shader program from shader handler
-    ShaderHandler* pShaderHandler = static_cast<ShaderHandler*>(m_pECS->getSystemSubscriber()->getComponentHandler(TID(ShaderHandler)));
+    ShaderHandler* pShaderHandler = static_cast<ShaderHandler*>(m_pECS->getComponentSubscriber()->getComponentHandler(TID(ShaderHandler)));
     if (!pShaderResourceHandler || !pShaderHandler) {
         return false;
     }

--- a/GameProject/Game/Level/Tube.cpp
+++ b/GameProject/Game/Level/Tube.cpp
@@ -39,7 +39,7 @@ TubeHandler::~TubeHandler()
 
 bool TubeHandler::init()
 {
-    m_pTextureLoader = static_cast<TextureLoader*>(m_pECS->getSystemSubscriber()->getComponentHandler(TID(TextureLoader)));
+    m_pTextureLoader = static_cast<TextureLoader*>(m_pECS->getComponentSubscriber()->getComponentHandler(TID(TextureLoader)));
     return m_pTextureLoader;
 }
 

--- a/GameProject/Game/Level/Tube.hpp
+++ b/GameProject/Game/Level/Tube.hpp
@@ -8,7 +8,7 @@
 
 struct Model;
 class ModelLoader;
-class SystemSubscriber;
+class ComponentSubscriber;
 class TextureLoader;
 
 struct TubePoint {

--- a/GameProject/Game/LightSpinner.cpp
+++ b/GameProject/Game/LightSpinner.cpp
@@ -13,7 +13,7 @@ LightSpinner::LightSpinner(ECSCore* pECS)
     this};
 
     subscribeToComponents(sysReg);
-    registerUpdate(&sysReg);
+    registerUpdate(sysReg);
 }
 
 LightSpinner::~LightSpinner()

--- a/GameProject/Game/Racer/Systems/RacerMover.cpp
+++ b/GameProject/Game/Racer/Systems/RacerMover.cpp
@@ -18,7 +18,7 @@ RacerMover::RacerMover(ECSCore* pECS)
     this};
 
     subscribeToComponents(sysReg);
-    registerUpdate(&sysReg);
+    registerUpdate(sysReg);
 }
 
 RacerMover::~RacerMover()

--- a/GameProject/Game/States/GameSession.cpp
+++ b/GameProject/Game/States/GameSession.cpp
@@ -20,19 +20,19 @@ GameSession::GameSession(MainMenu* mainMenu)
     LOG_INFO("Started game session");
 
     // Set mouse mode to relative, which also hides the mouse
-    this->inputHandler = static_cast<InputHandler*>(m_pECS->getSystemSubscriber()->getComponentHandler(TID(InputHandler)));
+    this->inputHandler = static_cast<InputHandler*>(m_pECS->getComponentSubscriber()->getComponentHandler(TID(InputHandler)));
     inputHandler->setMouseMode(DirectX::Mouse::Mode::MODE_RELATIVE);
     inputHandler->setMouseVisibility(false);
 
     // Create camera
     camera = m_pECS->createEntity();
 
-    TransformHandler* transformHandler = static_cast<TransformHandler*>(m_pECS->getSystemSubscriber()->getComponentHandler(TID(TransformHandler)));
+    TransformHandler* transformHandler = static_cast<TransformHandler*>(m_pECS->getComponentSubscriber()->getComponentHandler(TID(TransformHandler)));
     transformHandler->createTransform(camera);
     Transform& camTransform  = transformHandler->transforms.indexID(camera);
     camTransform.position    = {2.0f, 1.8f, 3.3f};
 
-    VPHandler* vpHandler = static_cast<VPHandler*>(m_pECS->getSystemSubscriber()->getComponentHandler(TID(VPHandler)));
+    VPHandler* vpHandler = static_cast<VPHandler*>(m_pECS->getComponentSubscriber()->getComponentHandler(TID(VPHandler)));
     DirectX::XMVECTOR camPos     = DirectX::XMLoadFloat3(&camTransform.position);
     DirectX::XMVECTOR camLookDir = transformHandler->getForward(camTransform.rotQuat);
     DirectX::XMVECTOR camUpDir   = {0.0f, 1.0f, 0.0f, 0.0f};
@@ -40,7 +40,7 @@ GameSession::GameSession(MainMenu* mainMenu)
     vpHandler->createProjMatrix(camera, 90.0f, 16.0f/9.0f, 0.1f, 20.0f);
 
     // Create renderable object
-    RenderableHandler* renderableHandler = static_cast<RenderableHandler*>(m_pECS->getSystemSubscriber()->getComponentHandler(TID(RenderableHandler)));
+    RenderableHandler* renderableHandler = static_cast<RenderableHandler*>(m_pECS->getComponentSubscriber()->getComponentHandler(TID(RenderableHandler)));
 
     renderableObject = m_pECS->createEntity();
     transformHandler->createTransform(renderableObject);
@@ -48,7 +48,7 @@ GameSession::GameSession(MainMenu* mainMenu)
     renderableHandler->createRenderable(renderableObject, "./Game/Assets/Models/Cube.dae", PROGRAM::BASIC);
 
     // Create point lights
-    LightHandler* lightHandler = static_cast<LightHandler*>(m_pECS->getSystemSubscriber()->getComponentHandler(TID(LightHandler)));
+    LightHandler* lightHandler = static_cast<LightHandler*>(m_pECS->getComponentSubscriber()->getComponentHandler(TID(LightHandler)));
 
     for (unsigned i = 0; i < MAX_POINTLIGHTS; i += 1) {
         Entity lightID = m_pECS->createEntity();

--- a/GameProject/Game/States/GameSession.cpp
+++ b/GameProject/Game/States/GameSession.cpp
@@ -3,7 +3,7 @@
 #include <Engine/ECS/ECSCore.hpp>
 #include <Engine/Rendering/Components/Renderable.hpp>
 #include <Engine/Rendering/Components/VPMatrices.hpp>
-#include <Engine/Rendering/Renderer.hpp>
+#include <Engine/Rendering/MeshRenderer.hpp>
 #include <Engine/Transform.hpp>
 #include <Engine/Utils/ECSUtils.hpp>
 #include <Engine/Utils/Logger.hpp>

--- a/GameProject/Game/States/MainMenu.cpp
+++ b/GameProject/Game/States/MainMenu.cpp
@@ -15,16 +15,16 @@ MainMenu::MainMenu(StateManager* stateManager, ECSCore* pECS, ID3D11Device* devi
     :State(stateManager, pECS, STATE_TRANSITION::PUSH),
     device(device)
 {
-    SystemSubscriber* pSystemSubscriber = pECS->getSystemSubscriber();
+    ComponentSubscriber* pComponentSubscriber = pECS->getComponentSubscriber();
 
-    this->inputHandler = static_cast<InputHandler*>(pSystemSubscriber->getComponentHandler(TID(InputHandler)));
+    this->inputHandler = static_cast<InputHandler*>(pComponentSubscriber->getComponentHandler(TID(InputHandler)));
     inputHandler->setMouseMode(DirectX::Mouse::Mode::MODE_ABSOLUTE);
     inputHandler->setMouseVisibility(true);
     this->keyboardState = inputHandler->getKeyboardState();
 
-    UIHandler* uiHandler            = static_cast<UIHandler*>(pSystemSubscriber->getComponentHandler(TID(UIHandler)));
-    TextRenderer* pTextRenderer     = static_cast<TextRenderer*>(pSystemSubscriber->getComponentHandler(TID(TextRenderer)));
-    TextureLoader* pTextureLoader   = static_cast<TextureLoader*>(pSystemSubscriber->getComponentHandler(TID(TextureLoader)));
+    UIHandler* uiHandler            = static_cast<UIHandler*>(pComponentSubscriber->getComponentHandler(TID(UIHandler)));
+    TextRenderer* pTextRenderer     = static_cast<TextRenderer*>(pComponentSubscriber->getComponentHandler(TID(TextRenderer)));
+    TextureLoader* pTextureLoader   = static_cast<TextureLoader*>(pComponentSubscriber->getComponentHandler(TID(TextureLoader)));
 
     // Create UI panel
     uiEntity = m_pECS->createEntity();
@@ -51,7 +51,7 @@ MainMenu::MainMenu(StateManager* stateManager, ECSCore* pECS, ID3D11Device* devi
     Entity soundEntity = m_pECS->createEntity();
     const std::string soundFile = "./Game/Assets/Sounds/muscle-car-daniel_simon.mp3";
 
-    SoundHandler* pSoundHandler = reinterpret_cast<SoundHandler*>(pSystemSubscriber->getComponentHandler(TID(SoundHandler)));
+    SoundHandler* pSoundHandler = reinterpret_cast<SoundHandler*>(pComponentSubscriber->getComponentHandler(TID(SoundHandler)));
     if (pSoundHandler->createSound(soundEntity, soundFile)) {
         pSoundHandler->playSound(soundEntity);
     }

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -150,7 +150,7 @@
     <ClCompile Include="Engine\Rendering\Components\VPMatrices.cpp" />
     <ClCompile Include="Engine\Rendering\Components\Renderable.cpp" />
     <ClCompile Include="Engine\Rendering\Display.cpp" />
-    <ClCompile Include="Engine\Rendering\Renderer.cpp" />
+    <ClCompile Include="Engine\Rendering\MeshRenderer.cpp" />
     <ClCompile Include="Engine\Rendering\ShaderHandler.cpp" />
     <ClCompile Include="Engine\Rendering\ShaderResourceHandler.cpp" />
     <ClCompile Include="Engine\Rendering\Text\TextRenderer.cpp" />
@@ -202,7 +202,7 @@
     <ClInclude Include="Engine\Rendering\Components\PointLight.hpp" />
     <ClInclude Include="Engine\Rendering\Components\Renderable.hpp" />
     <ClInclude Include="Engine\Rendering\Display.hpp" />
-    <ClInclude Include="Engine\Rendering\Renderer.hpp" />
+    <ClInclude Include="Engine\Rendering\MeshRenderer.hpp" />
     <ClInclude Include="Engine\Rendering\ShaderHandler.hpp" />
     <ClInclude Include="Engine\Rendering\ShaderResourceHandler.hpp" />
     <ClInclude Include="Engine\Rendering\Text\TextRenderer.hpp" />

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -136,6 +136,7 @@
     <ClCompile Include="Engine\ECS\ECSBooter.cpp" />
     <ClCompile Include="Engine\ECS\ECSCore.cpp" />
     <ClCompile Include="Engine\ECS\EntityRegistry.cpp" />
+    <ClCompile Include="Engine\ECS\Renderer.cpp" />
     <ClCompile Include="Engine\ECS\System.cpp" />
     <ClCompile Include="Engine\ECS\SystemSubscriber.cpp" />
     <ClCompile Include="Engine\ECS\SystemUpdater.cpp" />
@@ -184,6 +185,7 @@
     <ClInclude Include="Engine\ECS\ECSCore.hpp" />
     <ClInclude Include="Engine\ECS\Entity.hpp" />
     <ClInclude Include="Engine\ECS\EntityRegistry.hpp" />
+    <ClInclude Include="Engine\ECS\Renderer.hpp" />
     <ClInclude Include="Engine\ECS\System.hpp" />
     <ClInclude Include="Engine\ECS\SystemSubscriber.hpp" />
     <ClInclude Include="Engine\ECS\SystemUpdater.hpp" />

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -138,7 +138,7 @@
     <ClCompile Include="Engine\ECS\EntityRegistry.cpp" />
     <ClCompile Include="Engine\ECS\Renderer.cpp" />
     <ClCompile Include="Engine\ECS\System.cpp" />
-    <ClCompile Include="Engine\ECS\SystemSubscriber.cpp" />
+    <ClCompile Include="Engine\ECS\ComponentSubscriber.cpp" />
     <ClCompile Include="Engine\ECS\SystemUpdater.cpp" />
     <ClCompile Include="Engine\GameState\State.cpp" />
     <ClCompile Include="Engine\GameState\StateManager.cpp" />
@@ -187,7 +187,7 @@
     <ClInclude Include="Engine\ECS\EntityRegistry.hpp" />
     <ClInclude Include="Engine\ECS\Renderer.hpp" />
     <ClInclude Include="Engine\ECS\System.hpp" />
-    <ClInclude Include="Engine\ECS\SystemSubscriber.hpp" />
+    <ClInclude Include="Engine\ECS\ComponentSubscriber.hpp" />
     <ClInclude Include="Engine\ECS\SystemUpdater.hpp" />
     <ClInclude Include="Engine\GameState\State.hpp" />
     <ClInclude Include="Engine\GameState\StateManager.hpp" />


### PR DESCRIPTION
Up until this point, only systems have subscribed to components. Now, more classes, like a `Renderer` do so as well.

This is mostly achieved by having component subscriptions be linked to a subscription ID, as opposed to a system ID.

Also restyled some code.