### PR TITLE
ECS Renderer and RenderingHandler

### DIFF
--- a/GameProject/Engine/ECS/ComponentSubscriber.cpp
+++ b/GameProject/Engine/ECS/ComponentSubscriber.cpp
@@ -144,7 +144,7 @@ size_t ComponentSubscriber::subscribeToComponents(const std::vector<ComponentSub
     return subID;
 }
 
-void ComponentSubscriber::unsubscribeFromComponents(size_t subscriptionID, std::vector<std::type_index>& componentTypes)
+void ComponentSubscriber::unsubscribeFromComponents(size_t subscriptionID)
 {
     if (subscriptionStorage.hasElement(subscriptionID) == false) {
         LOG_WARNING("Attempted to deregistered an unregistered system, ID: %d", subscriptionID);

--- a/GameProject/Engine/ECS/ComponentSubscriber.hpp
+++ b/GameProject/Engine/ECS/ComponentSubscriber.hpp
@@ -49,7 +49,7 @@ public:
 
     // Returns a subscription ID
     size_t subscribeToComponents(const std::vector<ComponentSubscriptionRequest>& subscriptionRequests);
-    void unsubscribeFromComponents(size_t subscriptionID, std::vector<std::type_index>& componentTypes);
+    void unsubscribeFromComponents(size_t subscriptionID);
 
     // Notifies subscribed systems that a new component has been made
     void newComponent(Entity entityID, std::type_index componentType);

--- a/GameProject/Engine/ECS/ECSBooter.hpp
+++ b/GameProject/Engine/ECS/ECSBooter.hpp
@@ -8,6 +8,7 @@
 class ComponentHandler;
 class ECSCore;
 struct ComponentHandlerRegistration;
+struct RendererRegistration;
 struct SystemRegistration;
 
 struct ComponentHandlerBootInfo {
@@ -26,6 +27,7 @@ public:
 
     void enqueueComponentHandlerRegistration(const ComponentHandlerRegistration& handlerRegistration);
     void enqueueSystemRegistration(const SystemRegistration& systemRegistration);
+    void enqueueRendererRegistration(const RendererRegistration& rendererRegistration);
 
     void performBootups();
 
@@ -38,6 +40,7 @@ private:
 private:
     void bootHandlers();
     void bootSystems();
+    void bootRenderers();
 
     void buildBootInfos();
     // Get the map iterators of each handler's dependency, for faster lookups. Also remove dependencies that have already been booted.
@@ -49,6 +52,7 @@ private:
 
     std::vector<ComponentHandlerRegistration> m_ComponentHandlersToRegister;
     std::vector<SystemRegistration> m_SystemsToRegister;
+    std::vector<RendererRegistration> m_RenderersToRegister;
 
     // Maps handlers' types to their boot info
     std::unordered_map<std::type_index, ComponentHandlerBootInfo> m_HandlersBootInfos;

--- a/GameProject/Engine/ECS/ECSCore.cpp
+++ b/GameProject/Engine/ECS/ECSCore.cpp
@@ -30,6 +30,11 @@ void ECSCore::enqueueSystemRegistration(const SystemRegistration& systemRegistra
     m_ECSBooter.enqueueSystemRegistration(systemRegistration);
 }
 
+void ECSCore::enqueueRendererRegistration(const RendererRegistration& rendererRegistration)
+{
+    m_ECSBooter.enqueueRendererRegistration(rendererRegistration);
+}
+
 void ECSCore::performRegistrations()
 {
     // Initialize and register systems and component handlers

--- a/GameProject/Engine/ECS/ECSCore.hpp
+++ b/GameProject/Engine/ECS/ECSCore.hpp
@@ -4,6 +4,7 @@
 #include <Engine/ECS/ComponentSubscriber.hpp>
 #include <Engine/ECS/ECSBooter.hpp>
 #include <Engine/ECS/EntityRegistry.hpp>
+#include <Engine/ECS/Renderer.hpp>
 #include <Engine/ECS/System.hpp>
 #include <Engine/ECS/SystemUpdater.hpp>
 #include <Engine/Utils/IDGenerator.hpp>
@@ -25,6 +26,8 @@ public:
 
     void enqueueComponentHandlerRegistration(const ComponentHandlerRegistration& handlerRegistration);
     void enqueueSystemRegistration(const SystemRegistration& systemRegistration);
+    void enqueueRendererRegistration(const RendererRegistration& rendererRegistration);
+
     // Registers and initializes component handlers and systems
     void performRegistrations();
 

--- a/GameProject/Engine/ECS/Renderer.cpp
+++ b/GameProject/Engine/ECS/Renderer.cpp
@@ -3,25 +3,48 @@
 #include <Engine/Utils/DirectXUtils.hpp>
 #include <Engine/Utils/Logger.hpp>
 
-Renderer::Renderer(ECSCore* pECS)
+Renderer::Renderer(ECSCore* pECS, ID3D11Device* pDevice, ID3D11DeviceContext* pImmediateDevice)
     :m_pECS(pECS),
-    m_pDeferredContext(nullptr)
+    m_pDevice(pDevice),
+    m_pImmediateContext(pImmediateDevice)
 {}
 
 Renderer::~Renderer()
 {
-    if (m_pDeferredContext) {
-        m_pDeferredContext->Release();
-    }
+    m_pECS->getComponentSubscriber()->unsubscribeFromComponents(m_ComponentSubscriptionID);
 }
 
-bool Renderer::init(ID3D11Device* pDevice)
+void Renderer::registerRenderer(const RendererRegistration& rendererRegistration)
 {
-    HRESULT hr = pDevice->CreateDeferredContext(0, &m_pDeferredContext);
+    m_pECS->enqueueRendererRegistration(rendererRegistration);
+}
+
+ComponentHandler* Renderer::getComponentHandler(const std::type_index& handlerType)
+{
+    return m_pECS->getComponentSubscriber()->getComponentHandler(handlerType);
+}
+
+bool Renderer::createCommandBuffer(ID3D11DeviceContext** ppCommandBuffer)
+{
+    HRESULT hr = m_pDevice->CreateDeferredContext(0, ppCommandBuffer);
     if (FAILED(hr)) {
         LOG_ERROR("Failed to create deferred context: %s", hresultToString(hr).c_str());
         return false;
     }
 
+    return true;
+}
+
+bool Renderer::executeCommandBuffer(ID3D11DeviceContext* pCommandBuffer)
+{
+    ID3D11CommandList* pCommandList = nullptr;
+    HRESULT hr = pCommandBuffer->FinishCommandList(FALSE, &pCommandList);
+    if (FAILED(hr)) {
+        LOG_WARNING("Failed to finish command list: %s", hresultToString(hr).c_str());
+        return false;
+    }
+
+    m_pImmediateContext->ExecuteCommandList(pCommandList, FALSE);
+    pCommandList->Release();
     return true;
 }

--- a/GameProject/Engine/ECS/Renderer.hpp
+++ b/GameProject/Engine/ECS/Renderer.hpp
@@ -1,26 +1,44 @@
 #pragma once
 
+#define NOMINMAX
+
 #include <Engine/ECS/ECSCore.hpp>
 
 #include <d3d11.h>
 
+class Renderer;
+
+struct RendererRegistration {
+    std::vector<ComponentSubscriptionRequest> ComponentSubscriptionRequests;
+    Renderer* pRenderer;
+};
+
 class Renderer
 {
 public:
-    Renderer(ECSCore* pECS);
+    Renderer(ECSCore* pECS, ID3D11Device* pDevice, ID3D11DeviceContext* pImmediateDevice);
     ~Renderer();
 
-    bool init(ID3D11Device* pDevice);
-
+    virtual bool init() = 0;
     virtual void recordCommands() = 0;
+    virtual bool executeCommands() = 0;
 
-    void beginFrame();
-    void endFrame();
-    void executeCommands();
+    void setComponentSubscriptionID(size_t ID) { m_ComponentSubscriptionID = ID; }
+
+protected:
+    void registerRenderer(const RendererRegistration& rendererRegistration);
+    ComponentHandler* getComponentHandler(const std::type_index& handlerType);
+
+    bool createCommandBuffer(ID3D11DeviceContext** ppCommandBuffer);
+    bool executeCommandBuffer(ID3D11DeviceContext* pCommandBuffer);
+
+protected:
+    ID3D11Device* m_pDevice;
 
 private:
     ECSCore* m_pECS;
 
-    // Deferred context for recording commands
-    ID3D11DeviceContext* m_pDeferredContext;
+    ID3D11DeviceContext* m_pImmediateContext;
+
+    size_t m_ComponentSubscriptionID;
 };

--- a/GameProject/Engine/ECS/System.cpp
+++ b/GameProject/Engine/ECS/System.cpp
@@ -9,7 +9,7 @@ System::System(ECSCore* pECS)
 
 System::~System()
 {
-    m_pECS->getComponentSubscriber()->unsubscribeFromComponents(m_ComponentSubscriptionID, m_ComponentSubscriptionTypes);
+    m_pECS->getComponentSubscriber()->unsubscribeFromComponents(m_ComponentSubscriptionID);
 }
 
 void System::subscribeToComponents(const SystemRegistration& sysReg)

--- a/GameProject/Engine/ECS/System.hpp
+++ b/GameProject/Engine/ECS/System.hpp
@@ -64,8 +64,6 @@ protected:
 
     ComponentHandler* getComponentHandler(const std::type_index& handlerType);
 
-    std::vector<std::type_index> m_ComponentSubscriptionTypes;
-
 private:
     ECSCore* m_pECS;
 

--- a/GameProject/Engine/IGame.cpp
+++ b/GameProject/Engine/IGame.cpp
@@ -17,16 +17,15 @@ IGame::IGame(HINSTANCE hInstance)
     m_TextRenderer(&m_ECS, m_Display.getDevice(), m_Display.getDeviceContext()),
     m_UIHandler(&m_ECS, &m_Display),
     m_SoundHandler(&m_ECS),
-    m_MeshRenderer(&m_ECS, m_Display.getDevice(), m_Display.getDeviceContext(), m_Display.getRenderTarget(), m_Display.getDepthStencilView()),
-    m_UIRenderer(&m_ECS, m_Display.getDeviceContext(), m_Display.getDevice(), m_Display.getRenderTarget(), m_Display.getDepthStencilView()),
+    m_MeshRenderer(&m_ECS, &m_Display),
+    m_UIRenderer(&m_ECS, &m_Display),
     m_CameraSystem(&m_ECS),
-    m_ButtonSystem(&m_ECS, m_Display.getWindowWidth(), m_Display.getWindowHeight()),
+    m_ButtonSystem(&m_ECS, m_Display.getClientWidth(), m_Display.getClientHeight()),
     m_SoundPlayer(&m_ECS)
 {
     m_ECS.performRegistrations();
 
     m_Display.showWindow();
-    m_MeshRenderer.update(0.0f);
 }
 
 IGame::~IGame()
@@ -63,7 +62,8 @@ void IGame::run()
 
             // Render
             m_Display.clearBackBuffer();
-            m_MeshRenderer.update(dt);
+            m_MeshRenderer.recordCommands();
+            m_MeshRenderer.executeCommands();
             m_UIRenderer.update(dt);
             m_Display.presentBackBuffer();
 

--- a/GameProject/Engine/IGame.cpp
+++ b/GameProject/Engine/IGame.cpp
@@ -64,7 +64,8 @@ void IGame::run()
             m_Display.clearBackBuffer();
             m_MeshRenderer.recordCommands();
             m_MeshRenderer.executeCommands();
-            m_UIRenderer.update(dt);
+            m_UIRenderer.recordCommands();
+            m_UIRenderer.executeCommands();
             m_Display.presentBackBuffer();
 
             m_ECS.performMaintenance();

--- a/GameProject/Engine/IGame.cpp
+++ b/GameProject/Engine/IGame.cpp
@@ -23,6 +23,7 @@ IGame::IGame(HINSTANCE hInstance)
     m_RenderingHandler(&m_ECS, &m_Display)
 {
     m_ECS.performRegistrations();
+    m_Display.showWindow();
 }
 
 IGame::~IGame()
@@ -33,8 +34,6 @@ bool IGame::init()
     if (!m_RenderingHandler.init()) {
         return false;
     }
-
-    m_Display.showWindow();
 
     return true;
 }

--- a/GameProject/Engine/IGame.cpp
+++ b/GameProject/Engine/IGame.cpp
@@ -17,19 +17,27 @@ IGame::IGame(HINSTANCE hInstance)
     m_TextRenderer(&m_ECS, m_Display.getDevice(), m_Display.getDeviceContext()),
     m_UIHandler(&m_ECS, &m_Display),
     m_SoundHandler(&m_ECS),
-    m_MeshRenderer(&m_ECS, &m_Display),
-    m_UIRenderer(&m_ECS, &m_Display),
     m_CameraSystem(&m_ECS),
     m_ButtonSystem(&m_ECS, m_Display.getClientWidth(), m_Display.getClientHeight()),
-    m_SoundPlayer(&m_ECS)
+    m_SoundPlayer(&m_ECS),
+    m_RenderingHandler(&m_ECS, &m_Display)
 {
     m_ECS.performRegistrations();
-
-    m_Display.showWindow();
 }
 
 IGame::~IGame()
 {}
+
+bool IGame::init()
+{
+    if (!m_RenderingHandler.init()) {
+        return false;
+    }
+
+    m_Display.showWindow();
+
+    return true;
+}
 
 void IGame::run()
 {
@@ -57,16 +65,9 @@ void IGame::run()
 
             // Update logic
             m_StateManager.update(dt);
-
             m_ButtonSystem.update(dt);
 
-            // Render
-            m_Display.clearBackBuffer();
-            m_MeshRenderer.recordCommands();
-            m_MeshRenderer.executeCommands();
-            m_UIRenderer.recordCommands();
-            m_UIRenderer.executeCommands();
-            m_Display.presentBackBuffer();
+            m_RenderingHandler.render();
 
             m_ECS.performMaintenance();
         }

--- a/GameProject/Engine/IGame.hpp
+++ b/GameProject/Engine/IGame.hpp
@@ -11,13 +11,12 @@
 #include <Engine/Rendering/Components/Renderable.hpp>
 #include <Engine/Rendering/Components/VPMatrices.hpp>
 #include <Engine/Rendering/Display.hpp>
-#include <Engine/Rendering/MeshRenderer.hpp>
+#include <Engine/Rendering/RenderingHandler.hpp>
 #include <Engine/Rendering/ShaderHandler.hpp>
 #include <Engine/Rendering/ShaderResourceHandler.hpp>
 #include <Engine/Rendering/Text/TextRenderer.hpp>
 #include <Engine/UI/ButtonSystem.hpp>
 #include <Engine/UI/Panel.hpp>
-#include <Engine/UI/UIRenderer.hpp>
 #include <Engine/InputHandler.hpp>
 #include <Engine/Transform.hpp>
 
@@ -26,6 +25,8 @@ class IGame
 public:
     IGame(HINSTANCE hInstance);
     ~IGame();
+
+    bool init();
 
     // Starts the main loop
     void run();
@@ -49,11 +50,12 @@ protected:
     SoundHandler m_SoundHandler;
 
     // Systems
-    MeshRenderer m_MeshRenderer;
-    UIRenderer m_UIRenderer;
     CameraSystem m_CameraSystem;
     ButtonSystem m_ButtonSystem;
     SoundPlayer m_SoundPlayer;
+
+    // Rendering
+    RenderingHandler m_RenderingHandler;
 
     StateManager m_StateManager;
 };

--- a/GameProject/Engine/Rendering/Display.cpp
+++ b/GameProject/Engine/Rendering/Display.cpp
@@ -18,8 +18,8 @@ Display::Display(HINSTANCE hInstance, unsigned int clientHeight, float aspectRat
     windowed(windowed),
     swapChain(nullptr),
     renderTarget(nullptr),
-    clientHeight(clientHeight),
-    clientWidth((unsigned int)(clientHeight * aspectRatio))
+    m_ClientHeight(clientHeight),
+    m_ClientWidth((unsigned int)(clientHeight * aspectRatio))
 {
     LOG_INFO("Creating window");
 
@@ -74,18 +74,8 @@ void Display::presentBackBuffer()
 
 void Display::clearBackBuffer()
 {
-    deviceContext->ClearRenderTargetView(renderTarget.Get(), clearColor);
+    deviceContext->ClearRenderTargetView(renderTarget.Get(), m_pClearColor);
     deviceContext->ClearDepthStencilView(depthStencilView.Get(), D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0, 0);
-}
-
-unsigned int Display::getWindowWidth() const
-{
-    return clientWidth;
-}
-
-unsigned int Display::getWindowHeight() const
-{
-    return clientHeight;
 }
 
 void Display::initWindow()
@@ -104,10 +94,10 @@ void Display::initWindow()
         exit(1);
     }
 
-    RECT clientArea = {0, 0, (LONG)this->clientWidth, (LONG)this->clientHeight};
+    RECT clientArea = {0, 0, (LONG)m_ClientWidth, (LONG)m_ClientHeight};
     AdjustWindowRect(&clientArea, WS_OVERLAPPEDWINDOW, FALSE);
-    windowWidth = clientArea.right - clientArea.left;
-    windowHeight = clientArea.bottom - clientArea.top;
+    m_WindowWidth = clientArea.right - clientArea.left;
+    m_WindowHeight = clientArea.bottom - clientArea.top;
 
     this->hwnd = CreateWindow(
         "Game Name",
@@ -115,8 +105,8 @@ void Display::initWindow()
         WS_OVERLAPPEDWINDOW,
         CW_USEDEFAULT,
         CW_USEDEFAULT,
-        this->windowWidth,
-        this->windowHeight,
+        this->m_WindowWidth,
+        this->m_WindowHeight,
         nullptr,
         nullptr,
         this->hInstance,
@@ -142,7 +132,7 @@ void Display::initWindow()
 void Display::initDX()
 {
     // Single-threaded flag improves performance when D3D11 calls are only made on one thread
-    UINT deviceFlags = D3D11_CREATE_DEVICE_SINGLETHREADED;
+    UINT deviceFlags = 0;
 
     // If in debug mode, turn on D3D11 debugging
     #if defined _DEBUG
@@ -158,14 +148,14 @@ void Display::initDX()
     // Create swap chain description
     DXGI_SWAP_CHAIN_DESC swapChainDesc;
     ZeroMemory(&swapChainDesc, sizeof(DXGI_SWAP_CHAIN_DESC));
-    swapChainDesc.BufferDesc.Width = clientWidth;
-    swapChainDesc.BufferDesc.Height = clientHeight;
-    swapChainDesc.BufferDesc.RefreshRate.Numerator = frameRateLimit;
+    swapChainDesc.BufferDesc.Width = m_ClientWidth;
+    swapChainDesc.BufferDesc.Height = m_ClientHeight;
+    swapChainDesc.BufferDesc.RefreshRate.Numerator = m_FrameRateLimit;
     swapChainDesc.BufferDesc.RefreshRate.Denominator = 1;
     swapChainDesc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
     swapChainDesc.BufferDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
     swapChainDesc.BufferDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
-    swapChainDesc.SampleDesc.Count = this->multisamples;
+    swapChainDesc.SampleDesc.Count = this->m_Multisamples;
     swapChainDesc.SampleDesc.Quality = 0;
     swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT | DXGI_USAGE_UNORDERED_ACCESS;
     swapChainDesc.BufferCount = 2;
@@ -213,8 +203,8 @@ void Display::initDX()
     /* Depth stencil */
     D3D11_TEXTURE2D_DESC depthTxDesc;
     ZeroMemory(&depthTxDesc, sizeof(D3D11_TEXTURE2D_DESC));
-    depthTxDesc.Width = clientWidth;
-    depthTxDesc.Height = clientHeight;
+    depthTxDesc.Width = m_ClientWidth;
+    depthTxDesc.Height = m_ClientHeight;
     depthTxDesc.MipLevels = 1;
     depthTxDesc.ArraySize = 1;
     depthTxDesc.Format = DXGI_FORMAT_D32_FLOAT;
@@ -270,8 +260,8 @@ void Display::initDX()
     D3D11_VIEWPORT viewPort;
     viewPort.TopLeftX = 0;
     viewPort.TopLeftY = 0;
-    viewPort.Width = (float)clientWidth;
-    viewPort.Height = (float)clientHeight;
+    viewPort.Width = (float)m_ClientWidth;
+    viewPort.Height = (float)m_ClientHeight;
     viewPort.MinDepth = 0.0f;
     viewPort.MaxDepth = 1.0f;
     deviceContext->RSSetViewports(1, &viewPort);

--- a/GameProject/Engine/Rendering/Display.hpp
+++ b/GameProject/Engine/Rendering/Display.hpp
@@ -26,8 +26,8 @@ public:
     void presentBackBuffer();
     void clearBackBuffer();
 
-    unsigned int getWindowWidth() const;
-    unsigned int getWindowHeight() const;
+    unsigned int getClientWidth() const     { return m_ClientWidth; }
+    unsigned int getClientHeight() const    { return m_ClientHeight; }
 
     // Set to false when window is being closed (eg. alt+f4)
     static bool keepRunning;
@@ -55,14 +55,14 @@ private:
     Microsoft::WRL::ComPtr<ID3D11BlendState> mBlendState;
 
     // Color used to clear the back buffer
-    FLOAT clearColor[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+    FLOAT m_pClearColor[4] = {0.0f, 0.0f, 0.0f, 1.0f};
 
     bool windowed;
 
-    const unsigned int frameRateLimit = 60;
-    unsigned int clientWidth, clientHeight;
-    unsigned int windowWidth, windowHeight;
+    const unsigned int m_FrameRateLimit = 60;
+    unsigned int m_ClientWidth, m_ClientHeight;
+    unsigned int m_WindowWidth, m_WindowHeight;
 
     // MSAA, 1 multisample means no 'extra samples'
-    const unsigned int multisamples = 1;
+    const unsigned int m_Multisamples = 1;
 };

--- a/GameProject/Engine/Rendering/MeshRenderer.hpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
 #define NOMINMAX
-#include <Engine/ECS/System.hpp>
+#include <Engine/ECS/Renderer.hpp>
 #include <Engine/Rendering/Components/PointLight.hpp>
 #include <d3d11.h>
 
-#define MAX_POINTLIGHTS 7
+#define MAX_POINTLIGHTS 7u
 
+class Display;
 class RenderableHandler;
 class TransformHandler;
 class VPHandler;
@@ -22,28 +23,27 @@ struct PerFrameBuffer {
     DirectX::XMFLOAT4 padding;
 };
 
-class MeshRenderer : public System
+class MeshRenderer : public Renderer
 {
 public:
-    MeshRenderer(ECSCore* pECS, ID3D11Device* pDevice, ID3D11DeviceContext* pContext, ID3D11RenderTargetView* pRTV, ID3D11DepthStencilView* pDSV);
+    MeshRenderer(ECSCore* pECS, Display* pDisplay);
     ~MeshRenderer();
 
     virtual bool init() override;
-
-    void update(float dt);
+    virtual void recordCommands() override;
+    virtual bool executeCommands() override;
 
 private:
     IDVector<Entity> m_Renderables;
     IDVector<Entity> m_Camera;
     IDVector<Entity> m_PointLights;
 
+    ID3D11DeviceContext* m_pCommandBuffer;
+
     RenderableHandler* m_pRenderableHandler;
     TransformHandler* m_pTransformHandler;
     VPHandler* m_pVPHandler;
     LightHandler* m_pLightHandler;
-
-    ID3D11Device* m_pDevice;
-    ID3D11DeviceContext* m_pContext;
 
     /* Mesh input layout */
     ID3D11InputLayout* m_pMeshInputLayout;
@@ -63,4 +63,7 @@ private:
     ID3D11DepthStencilView* m_pDepthStencilView;
 
     ID3D11RasterizerState* m_RsState;
+
+    D3D11_VIEWPORT m_Viewport;
+    unsigned int m_BackbufferWidth, m_BackbufferHeight;
 };

--- a/GameProject/Engine/Rendering/RenderingHandler.cpp
+++ b/GameProject/Engine/Rendering/RenderingHandler.cpp
@@ -1,0 +1,57 @@
+#include "RenderingHandler.hpp"
+
+#include <Engine/ECS/Renderer.hpp>
+#include <Engine/Rendering/Display.hpp>
+#include <Engine/Utils/Logger.hpp>
+
+#include <thread>
+
+RenderingHandler::RenderingHandler(ECSCore* pECS, Display* pDisplay)
+    :m_pECS(pECS),
+    m_pDisplay(pDisplay),
+    m_MeshRenderer(pECS, pDisplay),
+    m_UIRenderer(pECS, pDisplay)
+{}
+
+RenderingHandler::~RenderingHandler()
+{}
+
+bool RenderingHandler::init()
+{
+    m_Renderers = {
+        &m_MeshRenderer,
+        &m_UIRenderer
+    };
+
+    return true;
+}
+
+void RenderingHandler::render()
+{
+    m_pDisplay->clearBackBuffer();
+
+    recordCommandBuffers();
+    executeCommandBuffers();
+
+    m_pDisplay->presentBackBuffer();
+}
+
+void RenderingHandler::recordCommandBuffers()
+{
+    std::vector<std::thread> threads;
+    threads.reserve(m_Renderers.size());
+
+    for (Renderer* pRenderer : m_Renderers) {
+        threads.push_back(std::thread(&Renderer::recordCommands, pRenderer));
+    }
+
+    for (std::thread& thread : threads) {
+        thread.join();
+    }
+}
+
+void RenderingHandler::executeCommandBuffers()
+{
+    m_MeshRenderer.executeCommands();
+    m_UIRenderer.executeCommands();
+}

--- a/GameProject/Engine/Rendering/RenderingHandler.hpp
+++ b/GameProject/Engine/Rendering/RenderingHandler.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <Engine/Rendering/MeshRenderer.hpp>
+#include <Engine/UI/UIRenderer.hpp>
+
+class RenderingHandler
+{
+public:
+    RenderingHandler(ECSCore* pECS, Display* pDisplay);
+    ~RenderingHandler();
+
+    bool init();
+
+    void render();
+
+private:
+    void recordCommandBuffers();
+    void executeCommandBuffers();
+
+private:
+    ECSCore* m_pECS;
+    Display* m_pDisplay;
+
+    std::vector<Renderer*> m_Renderers;
+
+    MeshRenderer m_MeshRenderer;
+    UIRenderer m_UIRenderer;
+};

--- a/GameProject/Engine/UI/Panel.cpp
+++ b/GameProject/Engine/UI/Panel.cpp
@@ -9,8 +9,8 @@
 
 UIHandler::UIHandler(ECSCore* pECS, Display* pDisplay)
     :ComponentHandler({tid_UIPanel}, pECS, std::type_index(typeid(UIHandler))),
-    m_ClientWidth(pDisplay->getWindowWidth()),
-    m_ClientHeight(pDisplay->getWindowHeight()),
+    m_ClientWidth(pDisplay->getClientWidth()),
+    m_ClientHeight(pDisplay->getClientHeight()),
     m_pDevice(pDisplay->getDevice()),
     m_pContext(pDisplay->getDeviceContext())
 {

--- a/GameProject/Engine/UI/UIRenderer.hpp
+++ b/GameProject/Engine/UI/UIRenderer.hpp
@@ -6,6 +6,7 @@
 #include <wrl/client.h>
 #include <d3d11.h>
 
+class Display;
 class ShaderHandler;
 class UIHandler;
 struct Program;
@@ -13,7 +14,7 @@ struct Program;
 class UIRenderer : public System
 {
 public:
-    UIRenderer(ECSCore* pECS, ID3D11DeviceContext* pContext, ID3D11Device* pDevice, ID3D11RenderTargetView* pRTV, ID3D11DepthStencilView* pDSV);
+    UIRenderer(ECSCore* pECS, Display* pDisplay);
     ~UIRenderer();
 
     virtual bool init() override;
@@ -43,4 +44,7 @@ private:
 
     /* Samplers */
     ID3D11SamplerState *const* m_ppAniSampler;
+
+    D3D11_VIEWPORT m_Viewport;
+    unsigned int m_BackbufferWidth, m_BackbufferHeight;
 };

--- a/GameProject/Engine/UI/UIRenderer.hpp
+++ b/GameProject/Engine/UI/UIRenderer.hpp
@@ -2,7 +2,7 @@
 
 #define NOMINMAX
 
-#include <Engine/ECS/System.hpp>
+#include <Engine/ECS/Renderer.hpp>
 #include <wrl/client.h>
 #include <d3d11.h>
 
@@ -11,27 +11,26 @@ class ShaderHandler;
 class UIHandler;
 struct Program;
 
-class UIRenderer : public System
+class UIRenderer : public Renderer
 {
 public:
     UIRenderer(ECSCore* pECS, Display* pDisplay);
     ~UIRenderer();
 
     virtual bool init() override;
-
-    void update(float dt);
+    virtual void recordCommands() override;
+    virtual bool executeCommands() override;
 
 private:
     IDVector<Entity> m_Panels;
+
+    ID3D11DeviceContext* m_pCommandBuffer;
 
     UIHandler* m_pUIHandler;
 
     ShaderHandler* m_pShaderHandler;
 
     Program* m_pUIProgram;
-
-    ID3D11Device* m_pDevice;
-    ID3D11DeviceContext* m_pContext;
 
     Microsoft::WRL::ComPtr<ID3D11Buffer> m_Quad;
 

--- a/GameProject/Engine/Utils/DirectXUtils.hpp
+++ b/GameProject/Engine/Utils/DirectXUtils.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
+#define NOMINMAX
+
+#include <d3d11.h>
 #include <DirectXMath.h>
 #include <system_error>
 #include <winerror.h>
+
+#define SAFERELEASE(pCOMObject) if (pCOMObject) { pCOMObject->Release(); }
 
 inline std::string hresultToString(HRESULT hr)
 {

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -152,6 +152,7 @@
     <ClCompile Include="Engine\Rendering\Components\Renderable.cpp" />
     <ClCompile Include="Engine\Rendering\Display.cpp" />
     <ClCompile Include="Engine\Rendering\MeshRenderer.cpp" />
+    <ClCompile Include="Engine\Rendering\RenderingHandler.cpp" />
     <ClCompile Include="Engine\Rendering\ShaderHandler.cpp" />
     <ClCompile Include="Engine\Rendering\ShaderResourceHandler.cpp" />
     <ClCompile Include="Engine\Rendering\Text\TextRenderer.cpp" />
@@ -205,6 +206,7 @@
     <ClInclude Include="Engine\Rendering\Components\Renderable.hpp" />
     <ClInclude Include="Engine\Rendering\Display.hpp" />
     <ClInclude Include="Engine\Rendering\MeshRenderer.hpp" />
+    <ClInclude Include="Engine\Rendering\RenderingHandler.hpp" />
     <ClInclude Include="Engine\Rendering\ShaderHandler.hpp" />
     <ClInclude Include="Engine\Rendering\ShaderResourceHandler.hpp" />
     <ClInclude Include="Engine\Rendering\Text\TextRenderer.hpp" />

--- a/GameProject/main.cpp
+++ b/GameProject/main.cpp
@@ -10,13 +10,17 @@
 
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, int nCmdShow)
 {
-	// Check for memory leaks. Disabled when not debugging
-	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+    // Check for memory leaks. Disabled when not debugging
+    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 
-	Logger::init();
+    Logger::init();
 
-	Game game(hInstance);
+    Game game(hInstance);
+    if (!game.init()) {
+        return 1;
+    }
+
     game.run();
 
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
- Renderers now use deferred contexts as opposed to immediate ones
- Renderers inherit from a `Renderer` base class, containing helper functions and functions for recording and executing commands
- Rendering commands are recorded using multiple threads