### PR TITLE
Simplify component handler constructor

### DIFF
--- a/GameProject/Engine/Audio/SoundHandler.cpp
+++ b/GameProject/Engine/Audio/SoundHandler.cpp
@@ -7,7 +7,7 @@
 #include <string>
 
 SoundHandler::SoundHandler(ECSCore* pECS)
-    :ComponentHandler({tid_sound}, pECS, TID(SoundHandler)),
+    :ComponentHandler(pECS, TID(SoundHandler)),
     m_pSystem(nullptr)
 {
     ComponentHandlerRegistration handlerReg = {};

--- a/GameProject/Engine/ECS/ComponentHandler.cpp
+++ b/GameProject/Engine/ECS/ComponentHandler.cpp
@@ -2,9 +2,8 @@
 
 #include <Engine/ECS/ECSCore.hpp>
 
-ComponentHandler::ComponentHandler(std::vector<std::type_index> handledTypes, ECSCore* pECS, std::type_index tid_handler)
-    :m_HandledTypes(handledTypes),
-    m_pECS(pECS),
+ComponentHandler::ComponentHandler(ECSCore* pECS, std::type_index tid_handler)
+    :m_pECS(pECS),
     m_TID(tid_handler)
 {}
 
@@ -15,6 +14,13 @@ ComponentHandler::~ComponentHandler()
 
 void ComponentHandler::registerHandler(const ComponentHandlerRegistration& handlerRegistration)
 {
+    // Write handled types
+    m_HandledTypes.reserve(handlerRegistration.ComponentRegistrations.size());
+
+    for (const ComponentRegistration& componentRegistration : handlerRegistration.ComponentRegistrations) {
+        m_HandledTypes.push_back(componentRegistration.tid);
+    }
+
     m_pECS->enqueueComponentHandlerRegistration(handlerRegistration);
 }
 

--- a/GameProject/Engine/ECS/ComponentHandler.hpp
+++ b/GameProject/Engine/ECS/ComponentHandler.hpp
@@ -29,8 +29,7 @@ struct ComponentHandlerRegistration {
 class ComponentHandler
 {
 public:
-    ComponentHandler(std::vector<std::type_index> handledTypes, ECSCore* pECS, std::type_index tid_handler);
-
+    ComponentHandler(ECSCore* pECS, std::type_index tid_handler);
     // Deregisters component handler and deletes components
     ~ComponentHandler();
 

--- a/GameProject/Engine/InputHandler.cpp
+++ b/GameProject/Engine/InputHandler.cpp
@@ -3,7 +3,7 @@
 #include <Engine/Utils/ECSUtils.hpp>
 
 InputHandler::InputHandler(ECSCore* pECS, HWND window)
-    :ComponentHandler({}, pECS, TID(InputHandler)),
+    :ComponentHandler(pECS, TID(InputHandler)),
     m_Window(window)
 {
     ComponentHandlerRegistration handlerReg = {};

--- a/GameProject/Engine/Rendering/AssetLoaders/ModelLoader.cpp
+++ b/GameProject/Engine/Rendering/AssetLoaders/ModelLoader.cpp
@@ -12,8 +12,8 @@
 #include <algorithm>
 
 ModelLoader::ModelLoader(ECSCore* pECS, TextureLoader* txLoader)
-    :m_pTXLoader(txLoader),
-    ComponentHandler({}, pECS, std::type_index(typeid(ModelLoader)))
+    :ComponentHandler(pECS, std::type_index(typeid(ModelLoader))),
+    m_pTXLoader(txLoader)
 {
     ComponentHandlerRegistration handlerReg = {};
     handlerReg.pComponentHandler = this;

--- a/GameProject/Engine/Rendering/AssetLoaders/TextureLoader.cpp
+++ b/GameProject/Engine/Rendering/AssetLoaders/TextureLoader.cpp
@@ -7,8 +7,8 @@
 #include <DirectXTK/WICTextureLoader.h>
 
 TextureLoader::TextureLoader(ECSCore* pECS, ID3D11Device* pDevice)
-    :m_pDevice(pDevice),
-    ComponentHandler({}, pECS, TID(TextureLoader))
+    :ComponentHandler(pECS, TID(TextureLoader)),
+    m_pDevice(pDevice)
 {
     ComponentHandlerRegistration handlerReg = {};
     handlerReg.pComponentHandler = this;

--- a/GameProject/Engine/Rendering/Components/PointLight.cpp
+++ b/GameProject/Engine/Rendering/Components/PointLight.cpp
@@ -1,7 +1,7 @@
 #include "PointLight.hpp"
 
 LightHandler::LightHandler(ECSCore* pECS)
-    :ComponentHandler({tid_pointLight}, pECS, TID(LightHandler))
+    :ComponentHandler(pECS, TID(LightHandler))
 {
     ComponentHandlerRegistration handlerReg = {};
     handlerReg.pComponentHandler = this;

--- a/GameProject/Engine/Rendering/Components/Renderable.cpp
+++ b/GameProject/Engine/Rendering/Components/Renderable.cpp
@@ -6,7 +6,7 @@
 #include <Engine/Utils/Logger.hpp>
 
 RenderableHandler::RenderableHandler(ECSCore* pECS)
-    :ComponentHandler({tid_renderable}, pECS, TID(RenderableHandler))
+    :ComponentHandler(pECS, TID(RenderableHandler))
 {
     ComponentHandlerRegistration handlerReg = {};
     handlerReg.pComponentHandler = this;

--- a/GameProject/Engine/Rendering/Components/VPMatrices.cpp
+++ b/GameProject/Engine/Rendering/Components/VPMatrices.cpp
@@ -3,7 +3,7 @@
 const float degreesToRadians = DirectX::XM_PI / 180.0f;
 
 VPHandler::VPHandler(ECSCore* pECS)
-    :ComponentHandler({tid_view, tid_projection}, pECS, TID(VPHandler))
+    :ComponentHandler(pECS, TID(VPHandler))
 {
     ComponentHandlerRegistration handlerReg = {};
     handlerReg.pComponentHandler = this;

--- a/GameProject/Engine/Rendering/ShaderHandler.cpp
+++ b/GameProject/Engine/Rendering/ShaderHandler.cpp
@@ -5,7 +5,7 @@
 #include <d3dcompiler.h>
 
 ShaderHandler::ShaderHandler(ID3D11Device* device, ECSCore* pECS)
-    :ComponentHandler({}, pECS, std::type_index(typeid(ShaderHandler))),
+    :ComponentHandler(pECS, std::type_index(typeid(ShaderHandler))),
     m_pDevice(device)
 {
     ComponentHandlerRegistration handlerReg = {};

--- a/GameProject/Engine/Rendering/ShaderResourceHandler.cpp
+++ b/GameProject/Engine/Rendering/ShaderResourceHandler.cpp
@@ -5,7 +5,7 @@
 #include <Engine/Utils/Logger.hpp>
 
 ShaderResourceHandler::ShaderResourceHandler(ECSCore* pECS, ID3D11Device* device)
-    :ComponentHandler({}, pECS, std::type_index(typeid(ShaderResourceHandler))),
+    :ComponentHandler(pECS, std::type_index(typeid(ShaderResourceHandler))),
     device(device)
 {
     ComponentHandlerRegistration handlerReg = {};

--- a/GameProject/Engine/Rendering/Text/TextRenderer.cpp
+++ b/GameProject/Engine/Rendering/Text/TextRenderer.cpp
@@ -10,7 +10,7 @@
 #include <algorithm>
 
 TextRenderer::TextRenderer(ECSCore* pECS, ID3D11Device* device, ID3D11DeviceContext* context)
-    :ComponentHandler({}, pECS, TID(TextRenderer)),
+    :ComponentHandler(pECS, TID(TextRenderer)),
     device(device),
     context(context)
 {

--- a/GameProject/Engine/Transform.cpp
+++ b/GameProject/Engine/Transform.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 
 TransformHandler::TransformHandler(ECSCore* pECS)
-    :ComponentHandler({tid_transform, tid_worldMatrix}, pECS, TID(TransformHandler))
+    :ComponentHandler(pECS, TID(TransformHandler))
 {
     ComponentHandlerRegistration handlerReg = {};
     handlerReg.pComponentHandler = this;

--- a/GameProject/Engine/UI/Panel.cpp
+++ b/GameProject/Engine/UI/Panel.cpp
@@ -8,7 +8,7 @@
 #include <Engine/Utils/Logger.hpp>
 
 UIHandler::UIHandler(ECSCore* pECS, Display* pDisplay)
-    :ComponentHandler({tid_UIPanel}, pECS, std::type_index(typeid(UIHandler))),
+    :ComponentHandler(pECS, std::type_index(typeid(UIHandler))),
     m_ClientWidth(pDisplay->getClientWidth()),
     m_ClientHeight(pDisplay->getClientHeight()),
     m_pDevice(pDisplay->getDevice()),

--- a/GameProject/Game/Level/Tube.cpp
+++ b/GameProject/Game/Level/Tube.cpp
@@ -17,7 +17,7 @@ const float deltaT = -0.0001f;
 const float textureLengthReciprocal = 1/4.0f;
 
 TubeHandler::TubeHandler(ECSCore* pECS, ID3D11Device* device)
-    :ComponentHandler({}, pECS, std::type_index(typeid(TubeHandler))),
+    :ComponentHandler(pECS, std::type_index(typeid(TubeHandler))),
     m_pDevice(device)
 {
 

--- a/GameProject/Game/Racer/Components/TrackPosition.cpp
+++ b/GameProject/Game/Racer/Components/TrackPosition.cpp
@@ -1,7 +1,7 @@
 #include "TrackPosition.hpp"
 
 TrackPositionHandler::TrackPositionHandler(ECSCore* pECS)
-    :ComponentHandler({tid_trackPosition}, pECS, TID(TrackPositionHandler))
+    :ComponentHandler(pECS, TID(TrackPositionHandler))
 {
     ComponentHandlerRegistration handlerReg = {};
     handlerReg.pComponentHandler = this;


### PR DESCRIPTION
There's no need to specify the handled components, since they are also mentioned in the handler registration.