### PR TITLE
Fix camera direction bug

### DIFF
--- a/GameProject/Engine/ECS/ECSCore.cpp
+++ b/GameProject/Engine/ECS/ECSCore.cpp
@@ -10,6 +10,7 @@ ECSCore::~ECSCore()
 
 void ECSCore::update(float dt)
 {
+    performDeletions();
     performRegistrations();
 
     m_SystemUpdater.updateMT(dt);
@@ -46,7 +47,7 @@ void ECSCore::deleteEntityDelayed(Entity entity)
     m_EntitiesToDelete.push_back(entity);
 }
 
-void ECSCore::performMaintenance()
+void ECSCore::performDeletions()
 {
     std::unordered_map<std::type_index, ComponentStorage>& componentStorage = m_ComponentSubscriber.getComponentStorage();
     const EntityRegistryPage& registryPage = m_EntityRegistry.getTopRegistryPage();

--- a/GameProject/Engine/ECS/ECSCore.hpp
+++ b/GameProject/Engine/ECS/ECSCore.hpp
@@ -33,7 +33,7 @@ public:
 
     // Enqueues an entity deletion, performed during maintenance
     void deleteEntityDelayed(Entity entity);
-    void performMaintenance();
+    void performDeletions();
 
     ComponentSubscriber* getComponentSubscriber() { return &m_ComponentSubscriber; }
     SystemUpdater* getSystemUpdater() { return &m_SystemUpdater; }

--- a/GameProject/Engine/GameState/StateManager.cpp
+++ b/GameProject/Engine/GameState/StateManager.cpp
@@ -58,8 +58,5 @@ void StateManager::update(float dt)
 {
     if (!m_States.empty()) {
         m_States.top()->update(dt);
-
-        m_pECS->performRegistrations();
-        m_pECS->getSystemUpdater()->updateMT(dt);
     }
 }

--- a/GameProject/Engine/IGame.cpp
+++ b/GameProject/Engine/IGame.cpp
@@ -63,12 +63,11 @@ void IGame::run()
             m_InputHandler.update();
 
             // Update logic
+            m_ECS.update(dt);
             m_StateManager.update(dt);
             m_ButtonSystem.update(dt);
 
             m_RenderingHandler.render();
-
-            m_ECS.performMaintenance();
         }
     }
 }


### PR DESCRIPTION
Fixes a bug where the camera's direction (and its up-vector) was pointing in an unexpected direction when the game session starts.

When changing mouse mode, the (x,y) positions in the mouse state don't reset until the operating system sends a new mouse position to the application, and InputHandler::update is called.

Closes #53 