### PR TITLE
Data-less IDVector

### DIFF
--- a/GameProject/Engine/Audio/SoundHandler.hpp
+++ b/GameProject/Engine/Audio/SoundHandler.hpp
@@ -27,7 +27,7 @@ public:
     FMOD::System* getSystem() { return m_pSystem; }
 
 public:
-    IDVector<Sound> m_Sounds;
+    IDDVector<Sound> m_Sounds;
 
 private:
     FMOD::System* m_pSystem;

--- a/GameProject/Engine/Audio/SoundPlayer.cpp
+++ b/GameProject/Engine/Audio/SoundPlayer.cpp
@@ -43,7 +43,7 @@ void SoundPlayer::update([[maybe_unused]] float dt)
         return;
     }
 
-    IDVector<Transform>& transforms = m_pTransformHandler->transforms;
+    IDDVector<Transform>& transforms = m_pTransformHandler->transforms;
     Transform& camTransform = transforms.indexID(m_Cameras[0]);
 
     DirectX::XMVECTOR camPos = DirectX::XMLoadFloat3(&camTransform.position);
@@ -54,9 +54,9 @@ void SoundPlayer::update([[maybe_unused]] float dt)
     float sqrtTwoRec = 1.0f / std::sqrtf(2.0f);
 
     size_t soundCount = m_Sounds.size();
-    IDVector<Sound>& sounds = m_pSoundHandler->m_Sounds;
+    IDDVector<Sound>& sounds = m_pSoundHandler->m_Sounds;
 
-    IDVector<PointLight>& pointLights = m_pLightHandler->pointLights;
+    IDDVector<PointLight>& pointLights = m_pLightHandler->pointLights;
 
     for (size_t soundNr = 0; soundNr < soundCount; soundNr++) {
         Entity soundEntity = m_Sounds[soundNr];

--- a/GameProject/Engine/Audio/SoundPlayer.hpp
+++ b/GameProject/Engine/Audio/SoundPlayer.hpp
@@ -18,8 +18,8 @@ public:
     virtual void update(float dt) override;
 
 private:
-    IDVector<Entity> m_Sounds;
-    IDVector<Entity> m_Cameras;
+    IDVector m_Sounds;
+    IDVector m_Cameras;
 
     LightHandler* m_pLightHandler;
     SoundHandler* m_pSoundHandler;

--- a/GameProject/Engine/ECS/ComponentSubscriber.cpp
+++ b/GameProject/Engine/ECS/ComponentSubscriber.cpp
@@ -132,7 +132,7 @@ size_t ComponentSubscriber::subscribeToComponents(const std::vector<ComponentSub
             bool registerEntity = m_pEntityRegistry->entityHasTypes(entity, subscription.componentTypes);
 
             if (registerEntity) {
-                subscription.subscriber->push_back(entity, entity);
+                subscription.subscriber->push_back(entity);
 
                 if (subscription.onEntityAdded != nullptr) {
                     subscription.onEntityAdded(entity);
@@ -195,7 +195,7 @@ void ComponentSubscriber::newComponent(Entity entityID, std::type_index componen
         ComponentSubscriptions& sysSub = subscriptionStorage.indexID(subBucketItr->second.systemID)[subBucketItr->second.subIdx];
 
         if (m_pEntityRegistry->entityHasTypes(entityID, sysSub.componentTypes)) {
-            sysSub.subscriber->push_back(entityID, entityID);
+            sysSub.subscriber->push_back(entityID);
 
             if (sysSub.onEntityAdded != nullptr) {
                 sysSub.onEntityAdded(entityID);

--- a/GameProject/Engine/ECS/ComponentSubscriber.hpp
+++ b/GameProject/Engine/ECS/ComponentSubscriber.hpp
@@ -18,7 +18,7 @@ struct ComponentHandlerRegistration;
 
 struct ComponentSubscriptions {
     // Stores IDs of entities found using subscription
-    IDVector<Entity>* subscriber; // TODO: Rename to... "foundEntities"?
+    IDVector* subscriber; // TODO: Rename to... "foundEntities"?
     std::vector<std::type_index> componentTypes;
     // Optional: Called after an entity was added due to the subscription
     std::function<void(Entity)> onEntityAdded;
@@ -65,7 +65,7 @@ private:
     std::unordered_multimap<std::type_index, SubscriptionStorageIndex> componentSubscriptions;
 
     // Map systems' IDs to their subscriptions
-    IDVector<std::vector<ComponentSubscriptions>> subscriptionStorage;
+    IDDVector<std::vector<ComponentSubscriptions>> subscriptionStorage;
     IDGenerator systemIdGen;
 
     std::unordered_map<std::type_index, ComponentHandler*> componentHandlers;

--- a/GameProject/Engine/ECS/EntityRegistry.hpp
+++ b/GameProject/Engine/ECS/EntityRegistry.hpp
@@ -9,7 +9,7 @@
 #include <unordered_set>
 
 // Map Entities to the set of component types they are registered to
-typedef IDVector<std::unordered_set<std::type_index>> EntityRegistryPage;
+typedef IDDVector<std::unordered_set<std::type_index>> EntityRegistryPage;
 
 class EntityRegistry
 {

--- a/GameProject/Engine/ECS/System.hpp
+++ b/GameProject/Engine/ECS/System.hpp
@@ -19,7 +19,7 @@ struct ComponentUpdateReg {
 // A request for a system to subscribe to one or more component types
 struct ComponentSubscriptionRequest {
     std::vector<ComponentUpdateReg> componentTypes;
-    IDVector<Entity>* subscriber;
+    IDVector* subscriber;
     // Optional: Called after an entity was added due to the subscription
     std::function<void(Entity)> onEntityAdded;
 };

--- a/GameProject/Engine/ECS/SystemUpdater.hpp
+++ b/GameProject/Engine/ECS/SystemUpdater.hpp
@@ -35,11 +35,11 @@ private:
 
     // Contains pointers to systems as well as information on what components they process and with what permissions
     // so that safe multi-threading can be performed
-    IDVector<SystemUpdateInfo> m_UpdateInfos;
+    IDDVector<SystemUpdateInfo> m_UpdateInfos;
 
     /* Resources for multi-threaded updates below */
     // Stores what systems have been processed during a multi-threaded pass, where an element is an index to the vector of systems
-    IDVector<size_t> processedSystems;
+    IDDVector<size_t> processedSystems;
 
     // Stores what components are currently being processed and with what rights
     std::unordered_multimap<std::type_index, ComponentPermissions> processingSystems;

--- a/GameProject/Engine/Rendering/Camera.hpp
+++ b/GameProject/Engine/Rendering/Camera.hpp
@@ -23,7 +23,7 @@ public:
     void update(float dt);
 
 private:
-    IDVector<Entity> m_Cameras;
+    IDVector m_Cameras;
 
     TransformHandler* m_pTransformHandler;
     VPHandler* m_pVPHandler;

--- a/GameProject/Engine/Rendering/Components/PointLight.hpp
+++ b/GameProject/Engine/Rendering/Components/PointLight.hpp
@@ -25,5 +25,5 @@ public:
 
     void createPointLight(Entity entity, DirectX::XMFLOAT3 position, DirectX::XMFLOAT3 light, float radius);
 
-    IDVector<PointLight> pointLights;
+    IDDVector<PointLight> pointLights;
 };

--- a/GameProject/Engine/Rendering/Components/Renderable.hpp
+++ b/GameProject/Engine/Rendering/Components/Renderable.hpp
@@ -31,7 +31,7 @@ public:
     // Creates a renderable component out of an existing model
     bool createRenderable(Entity entity, Model* model, PROGRAM program);
 
-    IDVector<Renderable> m_Renderables;
+    IDDVector<Renderable> m_Renderables;
 
 private:
     ShaderHandler* m_pShaderHandler;

--- a/GameProject/Engine/Rendering/Components/VPMatrices.hpp
+++ b/GameProject/Engine/Rendering/Components/VPMatrices.hpp
@@ -27,6 +27,6 @@ public:
     void createViewMatrix(Entity entity, DirectX::XMVECTOR eyePos, DirectX::XMVECTOR lookDir, DirectX::XMVECTOR upDir);
     void createProjMatrix(Entity entity, float horizontalFOV, float aspectRatio, float nearZ, float farZ);
 
-    IDVector<ViewMatrix> viewMatrices;
-    IDVector<ProjectionMatrix> projMatrices;
+    IDDVector<ViewMatrix> viewMatrices;
+    IDDVector<ProjectionMatrix> projMatrices;
 };

--- a/GameProject/Engine/Rendering/MeshRenderer.hpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.hpp
@@ -34,9 +34,9 @@ public:
     virtual bool executeCommands() override;
 
 private:
-    IDVector<Entity> m_Renderables;
-    IDVector<Entity> m_Camera;
-    IDVector<Entity> m_PointLights;
+    IDVector m_Renderables;
+    IDVector m_Camera;
+    IDVector m_PointLights;
 
     ID3D11DeviceContext* m_pCommandBuffer;
 

--- a/GameProject/Engine/Transform.hpp
+++ b/GameProject/Engine/Transform.hpp
@@ -37,8 +37,8 @@ public:
     // Requires that the entity has both a transform and world matrix component
     WorldMatrix& getWorldMatrix(Entity entity);
 
-    IDVector<Transform> transforms;
-    IDVector<WorldMatrix> worldMatrices;
+    IDDVector<Transform> transforms;
+    IDDVector<WorldMatrix> worldMatrices;
 
     // Transform calculation functions
     static DirectX::XMVECTOR getUp(const DirectX::XMFLOAT4& rotationQuat);

--- a/GameProject/Engine/UI/ButtonSystem.cpp
+++ b/GameProject/Engine/UI/ButtonSystem.cpp
@@ -39,7 +39,7 @@ void ButtonSystem::update(float dt)
         return;
     }
 
-    for (Entity entity : m_Buttons.getVec()) {
+    for (Entity entity : m_Buttons.getIDs()) {
         UIPanel& panel = m_pUIhandler->panels.indexID(entity);
         UIButton& button = m_pUIhandler->buttons.indexID(entity);
         panel.highlight = button.defaultHighlight;

--- a/GameProject/Engine/UI/ButtonSystem.hpp
+++ b/GameProject/Engine/UI/ButtonSystem.hpp
@@ -16,7 +16,7 @@ public:
     void update(float dt);
 
 private:
-    IDVector<Entity> m_Buttons;
+    IDVector m_Buttons;
 
     UIHandler* m_pUIhandler;
 

--- a/GameProject/Engine/UI/Panel.hpp
+++ b/GameProject/Engine/UI/Panel.hpp
@@ -87,8 +87,8 @@ public:
     void createButton(Entity entity, DirectX::XMFLOAT4 hoverHighlight, DirectX::XMFLOAT4 pressHighlight,
         std::function<void()> onPress);
 
-    IDVector<UIPanel> panels;
-    IDVector<UIButton> buttons;
+    IDDVector<UIPanel> panels;
+    IDDVector<UIButton> buttons;
 
 private:
     // Creates a texture for a panel, which can be used as both a RTV and SRV

--- a/GameProject/Engine/UI/UIRenderer.cpp
+++ b/GameProject/Engine/UI/UIRenderer.cpp
@@ -110,7 +110,7 @@ void UIRenderer::recordCommands()
         sizeof(DirectX::XMFLOAT4) + // Highlight color
         sizeof(float);              // Highlight factor
 
-    for (const Entity& entity : m_Panels.getVec()) {
+    for (const Entity& entity : m_Panels.getIDs()) {
         UIPanel& panel = m_pUIHandler->panels.indexID(entity);
         if (panel.texture->getSRV() == nullptr) {
             continue;

--- a/GameProject/Engine/UI/UIRenderer.hpp
+++ b/GameProject/Engine/UI/UIRenderer.hpp
@@ -22,7 +22,7 @@ public:
     virtual bool executeCommands() override;
 
 private:
-    IDVector<Entity> m_Panels;
+    IDVector m_Panels;
 
     ID3D11DeviceContext* m_pCommandBuffer;
 

--- a/GameProject/Engine/Utils/IDVector.hpp
+++ b/GameProject/Engine/Utils/IDVector.hpp
@@ -10,116 +10,117 @@
     * Pop elements in the middle of the array without breaking ID-index relation
 
     Stores elements, index for each ID and ID for each element
+
+    IDD: ID Data
 */
 
 template <typename T>
-class IDVector : public IDContainer
+class IDDVector : public IDContainer
 {
 public:
-    IDVector() {}
-    ~IDVector() {}
+    IDDVector() {}
+    ~IDDVector() {}
 
     // Index vector directly
     inline T operator[](size_t index) const
     {
-        return vec[index];
+        return m_Data[index];
     }
 
     inline T& operator[](size_t index)
     {
-        return vec[index];
+        return m_Data[index];
     }
 
     // Index vector using ID, assumes ID is linked to an element
     inline T indexID(size_t ID) const
     {
-        return vec[indices[ID]];
+        return m_Data[m_Indices[ID]];
     }
 
     inline T& indexID(size_t ID)
     {
-        return vec[indices[ID]];
+        return m_Data[m_Indices[ID]];
     }
 
-    // Returns ID of added element
     void push_back(const T& newElement, size_t ID)
     {
-        vec.push_back(newElement);
-        ids.push_back(ID);
+        m_Data.push_back(newElement);
+        m_IDs.push_back(ID);
 
         // Link element ID to index, resize ID vector in case ID is larger than the vector's size
-        if (indices.size() < ID+1) {
-            indices.resize(ID+1);
+        if (m_Indices.size() < ID + 1) {
+            m_Indices.resize(ID + 1);
         }
 
-        indices[ID] = vec.size()-1;
+        m_Indices[ID] = m_Data.size()-1;
     }
 
     void pop(size_t ID)
     {
-        size_t popIndex = indices[ID];
+        size_t popIndex = m_Indices[ID];
 
-        if (popIndex < vec.size()-1) {
+        if (popIndex < m_Data.size()-1) {
             // Replace to be popped element with the rear element
-            vec[popIndex] = vec.back();
-            ids[popIndex] = ids.back();
+            m_Data[popIndex] = m_Data.back();
+            m_IDs[popIndex] = m_IDs.back();
 
-            indices[ids.back()] = popIndex;
+            m_Indices[m_IDs.back()] = popIndex;
         }
 
-        vec.pop_back();
-        ids.pop_back();
+        m_Data.pop_back();
+        m_IDs.pop_back();
 
-        if (vec.empty()) {
-            indices.clear();
+        if (m_Data.empty()) {
+            m_Indices.clear();
         }
 
         // The rear elements in the indices vector might point at deleted elements, clean them up
-        while (indices.size() > vec.size() && indices.back() >= vec.size()) {
-            indices.pop_back();
+        while (m_Indices.size() > m_Data.size() && m_Indices.back() >= m_Data.size()) {
+            m_Indices.pop_back();
         }
     }
 
     void clear()
     {
-        vec.clear();
-        ids.clear();
-        indices.clear();
+        m_Data.clear();
+        m_IDs.clear();
+        m_Indices.clear();
     }
 
     inline bool hasElement(size_t ID) const
     {
         // Check if the ID pointed at by indices[ID] is the same as the parameter ID
-        return ID < indices.size() && ID == ids[indices[ID]];
+        return ID < m_Indices.size() && ID == m_IDs[m_Indices[ID]];
     }
 
     inline size_t size() const
     {
-        return vec.size();
+        return m_Data.size();
     }
 
     std::vector<T>& getVec()
     {
-        return this->vec;
+        return this->m_Data;
     }
 
     const std::vector<T>& getVec() const
     {
-        return this->vec;
+        return this->m_Data;
     }
 
     const std::vector<size_t>& getIDs() const
     {
-        return this->ids;
+        return this->m_IDs;
     }
 
     inline T& back()
     {
-        return this->vec.back();
+        return this->m_Data.back();
     }
 
 private:
-    std::vector<T> vec;
+    std::vector<T> m_Data;
 
     /*
         Stores indices to the main vector, use entity IDs to index it, eg:
@@ -127,8 +128,95 @@ private:
         or
         size_t entityIndex = indices[entityID];
     */
-    std::vector<size_t> indices;
+    std::vector<size_t> m_Indices;
 
     // Stores index for each ID, eg. ids[5] == vec[5].id (had vec's elements contained IDs)
-    std::vector<size_t> ids;
+    std::vector<size_t> m_IDs;
 };
+
+class IDVector : public IDContainer
+{
+public:
+    IDVector() {}
+    ~IDVector() {}
+
+    inline size_t operator[](size_t index) const
+    {
+        return m_IDs[index];
+    }
+
+    void push_back(size_t ID)
+    {
+        m_IDs.push_back(ID);
+
+        // Link element ID to index, resize ID vector in case ID is larger than the vector's size
+        if (m_Indices.size() < ID + 1) {
+            m_Indices.resize(ID + 1);
+        }
+
+        m_Indices[ID] = m_Indices.size() - 1;
+    }
+
+    void pop(size_t ID)
+    {
+        size_t popIndex = m_Indices[ID];
+
+        if (popIndex < m_IDs.size() - 1) {
+            // Replace to be popped element with the rear element
+            m_IDs[popIndex] = m_IDs.back();
+
+            m_Indices[m_IDs.back()] = popIndex;
+        }
+
+        m_IDs.pop_back();
+
+        if (m_IDs.empty()) {
+            m_Indices.clear();
+        }
+
+        // The rear elements in the indices vector might point at deleted elements, clean them up
+        while (m_Indices.size() > m_IDs.size() && m_Indices.back() >= m_IDs.size()) {
+            m_Indices.pop_back();
+        }
+    }
+
+    void clear()
+    {
+        m_IDs.clear();
+        m_Indices.clear();
+    }
+
+    inline bool hasElement(size_t ID) const
+    {
+        // Check if the ID pointed at by indices[ID] is the same as the parameter ID
+        return ID < m_Indices.size() && ID == m_IDs[m_Indices[ID]];
+    }
+
+    inline size_t size() const
+    {
+        return m_IDs.size();
+    }
+
+    const std::vector<size_t>& getIDs() const
+    {
+        return m_IDs;
+    }
+
+    inline size_t back()
+    {
+        return m_IDs.back();
+    }
+
+private:
+    /*
+        Stores indices to the main vector, use entity IDs to index it, eg:
+        T myElement = vec[indices[ID]];
+        or
+        size_t entityIndex = indices[entityID];
+    */
+    std::vector<size_t> m_Indices;
+
+    // Stores index for each ID, eg. ids[5] == vec[5].id (had vec's elements contained IDs)
+    std::vector<size_t> m_IDs;
+};
+

--- a/GameProject/Game/LightSpinner.hpp
+++ b/GameProject/Game/LightSpinner.hpp
@@ -16,5 +16,5 @@ public:
 
 private:
     LightHandler* m_pLightHandler;
-    IDVector<Entity> m_Lights;
+    IDVector m_Lights;
 };

--- a/GameProject/Game/Racer/Components/TrackPosition.hpp
+++ b/GameProject/Game/Racer/Components/TrackPosition.hpp
@@ -24,5 +24,5 @@ public:
 
     void createTrackPosition(Entity entity);
 
-    IDVector<TrackPosition> trackPositions;
+    IDDVector<TrackPosition> trackPositions;
 };

--- a/GameProject/Game/Racer/Systems/RacerMover.hpp
+++ b/GameProject/Game/Racer/Systems/RacerMover.hpp
@@ -36,7 +36,7 @@ public:
 private:
     void racerAdded(Entity entity);
 
-    IDVector<Entity> m_Racers;
+    IDVector m_Racers;
 
     TransformHandler* m_pTransformHandler;
     TrackPositionHandler* m_pTrackPositionHandler;


### PR DESCRIPTION
Systems and renderers only need to store IDs in their IDVectors. They used to store duplicates of these, using `IDVector<Entity>`.

`IDVector` has been renamed to `IDDVector<>,` and a new class called `IDVector` has been added. The new `IDVector` class only contains an ID vector and an indices vector.

Closes #52 