### PR TITLE
Eliminate duplicate TID subscriptions

### DIFF
--- a/GameProject/Engine/ECS/ComponentSubscriber.cpp
+++ b/GameProject/Engine/ECS/ComponentSubscriber.cpp
@@ -2,6 +2,7 @@
 
 #include <Engine/ECS/ComponentHandler.hpp>
 #include <Engine/ECS/System.hpp>
+#include <Engine/Utils/GeneralUtils.hpp>
 #include <Engine/Utils/Logger.hpp>
 
 ComponentSubscriber::ComponentSubscriber(EntityRegistry* pEntityRegistry)
@@ -101,6 +102,8 @@ size_t ComponentSubscriber::subscribeToComponents(const std::vector<ComponentSub
             newSub.componentTypes.push_back(componentReg.TID);
         }
 
+        eliminateDuplicates(newSub.componentTypes);
+        newSub.componentTypes.shrink_to_fit();
         subscriptions.push_back(newSub);
     }
 

--- a/GameProject/Engine/Utils/GeneralUtils.hpp
+++ b/GameProject/Engine/Utils/GeneralUtils.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <set>
+
+// Eliminate duplicates from a vector. Note that no memory is deallocated from the vector; its capacity remains the same.
+template <typename T>
+void eliminateDuplicates(std::vector<T>& vec)
+{
+    std::set<T> set;
+    for (const T& element : vec) {
+        set.insert(element);
+    }
+
+    vec.assign(set.begin(), set.end());
+}

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -219,6 +219,7 @@
     <ClInclude Include="Engine\UI\UIRenderer.hpp" />
     <ClInclude Include="Engine\Utils\DirectXUtils.hpp" />
     <ClInclude Include="Engine\Utils\ECSUtils.hpp" />
+    <ClInclude Include="Engine\Utils\GeneralUtils.hpp" />
     <ClInclude Include="Engine\Utils\IDContainer.hpp" />
     <ClInclude Include="Engine\Utils\IDGenerator.hpp" />
     <ClInclude Include="Engine\Utils\IDVector.hpp" />


### PR DESCRIPTION
When using component groups, it is possible to unknowingly enter the same component TID twice in a subscription. It could also be the case that different subscriptions made by the same system, contain the same TID multiple times.

The first case could be problematic for the component subscriber. The latter case could be problematic for the system updater as the system updater merges all TIDs of a system's respective subscriptions together.

The component subscriber and the system updater now eliminate these duplicates.