### PR TITLE
InputHandler V2

### DIFF
--- a/GameProject/Engine/InputHandler.cpp
+++ b/GameProject/Engine/InputHandler.cpp
@@ -49,3 +49,28 @@ void InputHandler::setMouseVisibility(bool visible)
     m_Mouse.SetVisible(visible);
     ShowCursor(visible);
 }
+
+// InputHandlerV2
+#include <Engine/Rendering/Window.hpp>
+
+InputHandlerV2::InputHandlerV2()
+{
+    for (bool& keyState : m_pKeyStates) {
+        keyState = false;
+    }
+}
+
+InputHandlerV2::~InputHandlerV2()
+{}
+
+void InputHandlerV2::keyActionCallbackStatic(GLFWwindow* pGLFWWindow, int key, int scancode, int action, int mods)
+{
+    // Retrieve pointer to InputHandler instance
+    Window* pWindow = reinterpret_cast<Window*>(glfwGetWindowUserPointer(pGLFWWindow));
+    pWindow->getInputHandler()->keyActionCallback(key, scancode, action, mods);
+}
+
+void InputHandlerV2::keyActionCallback(int key, int scancode, int action, int mods)
+{
+    m_pKeyStates[key] = action == GLFW_PRESS;
+}

--- a/GameProject/Engine/InputHandler.hpp
+++ b/GameProject/Engine/InputHandler.hpp
@@ -33,3 +33,23 @@ private:
 
     HWND m_Window;
 };
+
+#include <GLFW/glfw3.h>
+
+// TODO: Replace InputHandler
+class InputHandlerV2
+{
+public:
+    InputHandlerV2();
+    ~InputHandlerV2();
+
+public:
+    // Calls the stateful keyActionCallback
+    static void keyActionCallbackStatic(GLFWwindow* pWindow, int key, int scancode, int action, int mods);
+
+private:
+    void keyActionCallback(int key, int scancode, int action, int mods);
+
+private:
+    bool m_pKeyStates[GLFW_KEY_LAST];
+};

--- a/GameProject/Engine/Rendering/Window.cpp
+++ b/GameProject/Engine/Rendering/Window.cpp
@@ -25,7 +25,12 @@ bool Window::init()
         return false;
     }
 
+    // Callback functions eg. for key input are stateless. Setting this pointer allows them to become stateful by retrieving the Window
+    // pointer inside one of the callback functions
+    glfwSetWindowUserPointer(m_pWindow, this);
+
     glfwSetErrorCallback(Window::glfwErrorCallback);
+    glfwSetKeyCallback(m_pWindow, InputHandlerV2::keyActionCallbackStatic);
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
 

--- a/GameProject/Engine/Rendering/Window.hpp
+++ b/GameProject/Engine/Rendering/Window.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#define GLFW_EXPOSE_NATIVE_WIN32
+#include <Engine/InputHandler.hpp>
 
+#define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3.h>
 #include <GLFW/glfw3native.h>
 
@@ -20,6 +21,8 @@ public:
     bool shouldClose();
     HWND getHWND();
 
+    InputHandlerV2* getInputHandler() { return &m_InputHandler; }
+
 private:
     static void glfwErrorCallback(int error, const char* pDescription);
 
@@ -27,4 +30,5 @@ private:
     uint32_t m_ClientWidth, m_ClientHeight;
 
     GLFWwindow* m_pWindow;
+    InputHandlerV2 m_InputHandler;
 };


### PR DESCRIPTION
Since `GLFW` handles mouse and key input, the input handler needs a remake. This introduces a beginning of the rework, containing a class named `InputHandlerV2`, which handles keyboard input.