### PR TITLE
Buffer Abstraction

### DIFF
--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/BufferDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/BufferDX11.cpp
@@ -1,0 +1,82 @@
+#include "BufferDX11.hpp"
+
+#include <Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp>
+#include <Engine/Utils/DirectXUtils.hpp>
+#include <Engine/Utils/Logger.hpp>
+
+BufferDX11::BufferDX11(DeviceDX11* pDevice, const BufferInfo& bufferInfo)
+    :m_pBuffer(nullptr)
+{
+    D3D11_BUFFER_DESC bufferDesc;
+    ZeroMemory(&bufferDesc, sizeof(D3D11_BUFFER_DESC));
+    bufferDesc.ByteWidth = (UINT)bufferInfo.ByteSize;
+
+    // Figure out which usage flag to use
+    if (bufferInfo.Usage == BUFFER_USAGE::STAGING_BUFFER) {
+        bufferDesc.Usage = D3D11_USAGE_STAGING;
+    } else if (!HAS_FLAG(bufferInfo.CPUAccess | bufferInfo.GPUAccess, BUFFER_DATA_ACCESS::WRITE)) {
+        bufferDesc.Usage = D3D11_USAGE_IMMUTABLE;
+    } else if (HAS_FLAG(bufferInfo.CPUAccess, BUFFER_DATA_ACCESS::WRITE)) {
+        bufferDesc.Usage = D3D11_USAGE_DYNAMIC;
+    } else {
+        bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+    }
+
+    // Decide BindFlag
+    switch (bufferInfo.Usage) {
+        case BUFFER_USAGE::VERTEX_BUFFER:
+            bufferDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+            break;
+        case BUFFER_USAGE::INDEX_BUFFER:
+            bufferDesc.BindFlags = D3D11_BIND_INDEX_BUFFER;
+            break;
+        case BUFFER_USAGE::UNIFORM_BUFFER:
+        case BUFFER_USAGE::STAGING_BUFFER:
+            bufferDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+            break;
+        default:
+            LOG_ERROR("Invalid buffer usage flag: %d", bufferInfo.Usage);
+            break;
+    }
+
+    bufferDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ * HAS_FLAG(bufferInfo.CPUAccess, BUFFER_DATA_ACCESS::READ)
+                            | D3D11_CPU_ACCESS_WRITE * HAS_FLAG(bufferInfo.CPUAccess, BUFFER_DATA_ACCESS::READ);
+    bufferDesc.MiscFlags = 0;
+    bufferDesc.StructureByteStride = 0;
+
+    D3D11_SUBRESOURCE_DATA bufferData;
+    bufferData.pSysMem = bufferInfo.pData;
+    bufferData.SysMemPitch = 0;
+    bufferData.SysMemSlicePitch = 0;
+
+    HRESULT hr = pDevice->getDevice()->CreateBuffer(&bufferDesc, bufferInfo.pData ? &bufferData : nullptr, &m_pBuffer);
+    if (FAILED(hr)) {
+        LOG_WARNING("Failed to create buffer: %s", hresultToString(hr).c_str());
+        return;
+    }
+
+    return;
+}
+
+void BufferDX11::bind(SHADER_TYPE shaderStageFlags, int slot, ID3D11DeviceContext* pContext)
+{
+    if (HAS_FLAG(shaderStageFlags, SHADER_TYPE::VERTEX_SHADER)) {
+        pContext->VSSetConstantBuffers((UINT)slot, 1, &m_pBuffer);
+    }
+
+    if (HAS_FLAG(shaderStageFlags, SHADER_TYPE::HULL_SHADER)) {
+        pContext->HSSetConstantBuffers((UINT)slot, 1, &m_pBuffer);
+    }
+
+    if (HAS_FLAG(shaderStageFlags, SHADER_TYPE::DOMAIN_SHADER)) {
+        pContext->DSSetConstantBuffers((UINT)slot, 1, &m_pBuffer);
+    }
+
+    if (HAS_FLAG(shaderStageFlags, SHADER_TYPE::GEOMETRY_SHADER)) {
+        pContext->GSSetConstantBuffers((UINT)slot, 1, &m_pBuffer);
+    }
+
+    if (HAS_FLAG(shaderStageFlags, SHADER_TYPE::FRAGMENT_SHADER)) {
+        pContext->PSSetConstantBuffers((UINT)slot, 1, &m_pBuffer);
+    }
+}

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/BufferDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/BufferDX11.cpp
@@ -36,7 +36,7 @@ BufferDX11::BufferDX11(DeviceDX11* pDevice, const BufferInfo& bufferInfo)
             break;
         default:
             LOG_ERROR("Invalid buffer usage flag: %d", bufferInfo.Usage);
-            break;
+            return;
     }
 
     bufferDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ * HAS_FLAG(bufferInfo.CPUAccess, BUFFER_DATA_ACCESS::READ)
@@ -52,10 +52,14 @@ BufferDX11::BufferDX11(DeviceDX11* pDevice, const BufferInfo& bufferInfo)
     HRESULT hr = pDevice->getDevice()->CreateBuffer(&bufferDesc, bufferInfo.pData ? &bufferData : nullptr, &m_pBuffer);
     if (FAILED(hr)) {
         LOG_WARNING("Failed to create buffer: %s", hresultToString(hr).c_str());
-        return;
     }
+}
 
-    return;
+BufferDX11::~BufferDX11()
+{
+    if (m_pBuffer) {
+        m_pBuffer->Release();
+    }
 }
 
 void BufferDX11::bind(SHADER_TYPE shaderStageFlags, int slot, ID3D11DeviceContext* pContext)

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/BufferDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/BufferDX11.hpp
@@ -15,6 +15,8 @@ public:
 
     void bind(SHADER_TYPE shaderStageFlags, int slot, ID3D11DeviceContext* pContext);
 
+    ID3D11Buffer* getBuffer() { return m_pBuffer; }
+
 private:
     ID3D11Buffer* m_pBuffer;
 };

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/BufferDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/BufferDX11.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Engine/Rendering/APIAbstractions/IBuffer.hpp>
+#include <Engine/Rendering/APIAbstractions/Shader.hpp>
+
+class DeviceDX11;
+struct ID3D11Buffer;
+struct ID3D11DeviceContext;
+
+class BufferDX11
+{
+public:
+    BufferDX11(DeviceDX11* pDevice, const BufferInfo& bufferInfo);
+    ~BufferDX11();
+
+    void bind(SHADER_TYPE shaderStageFlags, int slot, ID3D11DeviceContext* pContext);
+
+private:
+    ID3D11Buffer* m_pBuffer;
+};

--- a/GameProject/Engine/Rendering/APIAbstractions/IBuffer.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/IBuffer.cpp
@@ -1,0 +1,3 @@
+#include "IBuffer.hpp"
+
+DEFINE_BITMASK(BUFFER_DATA_ACCESS)

--- a/GameProject/Engine/Rendering/APIAbstractions/IBuffer.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/IBuffer.hpp
@@ -28,4 +28,7 @@ struct BufferInfo {
 };
 
 class IBuffer
-{};
+{
+public:
+    virtual ~IBuffer() = 0;
+};

--- a/GameProject/Engine/Rendering/APIAbstractions/IBuffer.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/IBuffer.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <Engine/Utils/EnumClass.hpp>
+
+#include <stdint.h>
+
+enum class BUFFER_DATA_ACCESS : uint32_t {
+    NONE    = 0,
+    READ    = 1,
+    WRITE   = READ << 1
+};
+
+DECLARE_BITMASK(BUFFER_DATA_ACCESS)
+
+enum class BUFFER_USAGE : uint32_t {
+    VERTEX_BUFFER   = 1,
+    INDEX_BUFFER    = VERTEX_BUFFER << 1,
+    UNIFORM_BUFFER  = INDEX_BUFFER  << 1,
+    STAGING_BUFFER  = UNIFORM_BUFFER << 1
+};
+
+struct BufferInfo {
+    size_t ByteSize;
+    const void* pData;
+    BUFFER_DATA_ACCESS CPUAccess;
+    BUFFER_DATA_ACCESS GPUAccess;
+    BUFFER_USAGE Usage;
+};
+
+class IBuffer
+{};

--- a/GameProject/Engine/Rendering/APIAbstractions/Shader.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Shader.cpp
@@ -1,0 +1,3 @@
+#include "Shader.hpp"
+
+DEFINE_BITMASK(SHADER_TYPE)

--- a/GameProject/Engine/Rendering/APIAbstractions/Shader.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Shader.hpp
@@ -2,7 +2,9 @@
 
 #include <Engine/Utils/EnumClass.hpp>
 
-enum class SHADER_TYPE {
+#include <stdint.h>
+
+enum class SHADER_TYPE : uint32_t {
     VERTEX_SHADER   = 1,
     HULL_SHADER     = VERTEX_SHADER << 1,
     DOMAIN_SHADER   = HULL_SHADER   << 1,

--- a/GameProject/Engine/Rendering/APIAbstractions/Shader.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Shader.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <Engine/Utils/EnumClass.hpp>
+
+enum class SHADER_TYPE {
+    VERTEX_SHADER   = 1,
+    HULL_SHADER     = VERTEX_SHADER << 1,
+    DOMAIN_SHADER   = HULL_SHADER   << 1,
+    GEOMETRY_SHADER = DOMAIN_SHADER << 1,
+    FRAGMENT_SHADER = GEOMETRY_SHADER << 1
+};
+
+DECLARE_BITMASK(SHADER_TYPE)

--- a/GameProject/Engine/Rendering/AssetContainers/Model.hpp
+++ b/GameProject/Engine/Rendering/AssetContainers/Model.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
 #include <Engine/Rendering/AssetContainers/Material.hpp>
-#include <d3d11.h>
+#include <Engine/Rendering/APIAbstractions/DX11/BufferDX11.hpp>
+
+#include <DirectXMath.h>
 #include <vector>
 
 struct Vertex2D {
-    DirectX::XMFLOAT2 position;
-    DirectX::XMFLOAT2 txCoords;
+    DirectX::XMFLOAT2 Position;
+    DirectX::XMFLOAT2 TXCoords;
 };
 
 struct Vertex {
@@ -16,19 +18,19 @@ struct Vertex {
 };
 
 struct Mesh {
-    ID3D11Buffer* vertexBuffer, *indexBuffer;
+    BufferDX11* pVertexBuffer, *pIndexBuffer;
     size_t vertexCount, indexCount, materialIndex;
 };
 
 struct Model {
-    std::vector<Mesh> meshes;
-    std::vector<Material> materials;
+    std::vector<Mesh> Meshes;
+    std::vector<Material> Materials;
 };
 
 inline void releaseModel(Model* pModel)
 {
-    for (size_t i = 0; i < pModel->meshes.size(); i += 1) {
-        pModel->meshes[i].vertexBuffer->Release();
-        pModel->meshes[i].indexBuffer->Release();
+    for (Mesh& mesh : pModel->Meshes) {
+        delete mesh.pVertexBuffer;
+        delete mesh.pIndexBuffer;
     }
 }

--- a/GameProject/Engine/Rendering/MeshRenderer.cpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.cpp
@@ -188,8 +188,8 @@ void MeshRenderer::recordCommands()
 
         DirectX::XMMATRIX camVP = DirectX::XMLoadFloat4x4(&vpMatrices.View) * DirectX::XMLoadFloat4x4(&vpMatrices.Projection);
 
-        for (const Mesh& mesh : model->meshes) {
-            if (model->materials[mesh.materialIndex].textures.empty()) {
+        for (const Mesh& mesh : model->Meshes) {
+            if (model->Materials[mesh.materialIndex].textures.empty()) {
                 // Will not render the mesh if it does not have a texture
                 continue;
             }
@@ -197,8 +197,10 @@ void MeshRenderer::recordCommands()
             // Vertex buffer
             m_pCommandBuffer->IASetInputLayout(program->inputLayout);
             UINT offsets = 0;
-            m_pCommandBuffer->IASetVertexBuffers(0, 1, &mesh.vertexBuffer, &program->vertexSize, &offsets);
-            m_pCommandBuffer->IASetIndexBuffer(mesh.indexBuffer, DXGI_FORMAT_R32_UINT, 0);
+            ID3D11Buffer* pVertexBuffer = mesh.pVertexBuffer->getBuffer();
+
+            m_pCommandBuffer->IASetVertexBuffers(0, 1, &pVertexBuffer, &program->vertexSize, &offsets);
+            m_pCommandBuffer->IASetIndexBuffer(mesh.pIndexBuffer->getBuffer(), DXGI_FORMAT_R32_UINT, 0);
 
             /* Vertex shader */
             PerObjectMatrices matrices;
@@ -216,13 +218,13 @@ void MeshRenderer::recordCommands()
 
             /* Pixel shader */
             // Diffuse texture
-            ID3D11ShaderResourceView* pDiffuseSRV = model->materials[mesh.materialIndex].textures[0].getSRV();
+            ID3D11ShaderResourceView* pDiffuseSRV = model->Materials[mesh.materialIndex].textures[0].getSRV();
             m_pCommandBuffer->PSSetShaderResources(0, 1, &pDiffuseSRV);
             m_pCommandBuffer->PSSetSamplers(0, 1, m_ppAniSampler);
 
             // Material cbuffer
             m_pCommandBuffer->Map(m_pMaterialBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResources);
-            memcpy(mappedResources.pData, &model->materials[mesh.materialIndex].attributes, sizeof(MaterialAttributes));
+            memcpy(mappedResources.pData, &model->Materials[mesh.materialIndex].attributes, sizeof(MaterialAttributes));
             m_pCommandBuffer->Unmap(m_pMaterialBuffer, 0);
             m_pCommandBuffer->PSSetConstantBuffers(0, 1, &m_pMaterialBuffer);
 

--- a/GameProject/Engine/Rendering/ShaderHandler.cpp
+++ b/GameProject/Engine/Rendering/ShaderHandler.cpp
@@ -64,7 +64,7 @@ bool ShaderHandler::initHandler()
         },
     };
     UINT vertexSize = 32;
-    m_Programs.push_back(compileProgram(L"Basic", {VERTEX_SHADER, PIXEL_SHADER}, inputLayoutDesc, vertexSize));
+    m_Programs.push_back(compileProgram(L"Basic", {SHADER_TYPE::VERTEX_SHADER, SHADER_TYPE::FRAGMENT_SHADER}, inputLayoutDesc, vertexSize));
 
     // Compile UI program
     inputLayoutDesc = {
@@ -88,7 +88,7 @@ bool ShaderHandler::initHandler()
         },
     };
     vertexSize = 16;
-    m_Programs.push_back(compileProgram(L"UI", {VERTEX_SHADER, PIXEL_SHADER}, inputLayoutDesc, vertexSize));
+    m_Programs.push_back(compileProgram(L"UI", {SHADER_TYPE::VERTEX_SHADER, SHADER_TYPE::FRAGMENT_SHADER}, inputLayoutDesc, vertexSize));
 
     return true;
 }
@@ -111,7 +111,7 @@ Program ShaderHandler::compileProgram(LPCWSTR programName, std::vector<SHADER_TY
 
     for (SHADER_TYPE shaderType : shaderTypes) {
         switch (shaderType) {
-            case VERTEX_SHADER:
+            case SHADER_TYPE::VERTEX_SHADER:
                 filePath = std::wstring(SHADERS_PATH) + programName + VS_POSTFIX;
                 compiledCode = compileShader(filePath.c_str(), VS_ENTRYPOINT, VS_TARGET);
 
@@ -134,7 +134,7 @@ Program ShaderHandler::compileProgram(LPCWSTR programName, std::vector<SHADER_TY
                     LOG_ERROR("Failed to create mesh input layout: %s", hresultToString(hr).c_str());
                 break;
 
-            case PIXEL_SHADER:
+            case SHADER_TYPE::FRAGMENT_SHADER:
                 filePath = std::wstring(SHADERS_PATH) + programName + PS_POSTFIX;
                 compiledCode = compileShader(filePath.c_str(), PS_ENTRYPOINT, PS_TARGET);
 

--- a/GameProject/Engine/Rendering/ShaderHandler.hpp
+++ b/GameProject/Engine/Rendering/ShaderHandler.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Engine/ECS/ComponentHandler.hpp>
+#include <Engine/Rendering/APIAbstractions/Shader.hpp>
+
 #include <d3d11.h>
 #include <vector>
 
@@ -13,14 +15,6 @@ const LPCWSTR VS_POSTFIX = L"_VS.hlsl";
 const LPCSTR PS_ENTRYPOINT = "PS_main";
 const LPCSTR PS_TARGET = "ps_5_0";
 const LPCWSTR PS_POSTFIX = L"_PS.hlsl";
-
-enum SHADER_TYPE {
-    VERTEX_SHADER,
-    HULL_SHADER,
-    DOMAIN_SHADER,
-    GEOMETRY_SHADER,
-    PIXEL_SHADER
-};
 
 enum PROGRAM
 {

--- a/GameProject/Engine/Rendering/ShaderResourceHandler.hpp
+++ b/GameProject/Engine/Rendering/ShaderResourceHandler.hpp
@@ -6,6 +6,7 @@
 #include <d3d11.h>
 #include <wrl/client.h>
 
+class BufferDX11;
 class IDevice;
 struct Vertex;
 
@@ -17,12 +18,12 @@ public:
 
     virtual bool initHandler() override;
 
-    bool createVertexBuffer(const void* vertices, size_t vertexSize, size_t vertexCount, ID3D11Buffer** targetBuffer);
-    bool createIndexBuffer(unsigned* indices, size_t indexCount, ID3D11Buffer** targetBuffer);
+    BufferDX11* createVertexBuffer(const void* pVertices, size_t vertexSize, size_t vertexCount);
+    BufferDX11* createIndexBuffer(const unsigned* pIndices, size_t indexCount);
 
     ID3D11SamplerState *const* getAniSampler() const;
 
-    Microsoft::WRL::ComPtr<ID3D11Buffer> getQuarterScreenQuad();
+    BufferDX11* getQuarterScreenQuad();
 
 private:
     IDevice* m_pDevice;
@@ -31,5 +32,5 @@ private:
     Microsoft::WRL::ComPtr<ID3D11SamplerState> aniSampler;
 
     // Quarter-screen quad
-    Microsoft::WRL::ComPtr<ID3D11Buffer> quad;
+    BufferDX11* m_pQuadVertices;
 };

--- a/GameProject/Engine/UI/Panel.hpp
+++ b/GameProject/Engine/UI/Panel.hpp
@@ -10,7 +10,6 @@
 #include <DirectXMath.h>
 #include <d3d11.h>
 #include <string>
-#include <wrl/client.h>
 
 enum TX_HORIZONTAL_ALIGNMENT {
     TX_HORIZONTAL_ALIGNMENT_LEFT,
@@ -69,6 +68,7 @@ struct UIButton {
 
 const std::type_index tid_UIButton = TID(UIButton);
 
+class BufferDX11;
 class Display;
 class IDevice;
 class Window;
@@ -104,7 +104,7 @@ private:
 
     Program* m_pUIProgram;
     ID3D11Buffer* m_pPerObjectBuffer;
-    Microsoft::WRL::ComPtr<ID3D11Buffer> m_Quad;
+    BufferDX11* m_pQuadVertices;
     ID3D11SamplerState *const* m_pAniSampler;
 
     unsigned int m_ClientWidth, m_ClientHeight;

--- a/GameProject/Engine/UI/UIRenderer.cpp
+++ b/GameProject/Engine/UI/UIRenderer.cpp
@@ -15,7 +15,8 @@ UIRenderer::UIRenderer(ECSCore* pECS, DeviceDX11* pDevice, Window* pWindow)
     m_pRenderTarget(pDevice->getBackBuffer()),
     m_pDepthStencilView(pDevice->getDepthStencilView()),
     m_BackbufferWidth(pWindow->getWidth()),
-    m_BackbufferHeight(pWindow->getHeight())
+    m_BackbufferHeight(pWindow->getHeight()),
+    m_pQuad(nullptr)
 {
     RendererRegistration rendererReg = {};
     rendererReg.SubscriberRegistration.ComponentSubscriptionRequests = {
@@ -46,7 +47,7 @@ bool UIRenderer::init()
 
     m_pUIProgram = m_pShaderHandler->getProgram(UI);
 
-    m_Quad = pShaderResourceHandler->getQuarterScreenQuad();
+    m_pQuad = pShaderResourceHandler->getQuarterScreenQuad();
     m_ppAniSampler = pShaderResourceHandler->getAniSampler();
 
     // Create per-panel constant buffer
@@ -92,8 +93,11 @@ void UIRenderer::recordCommands()
 
     m_pCommandBuffer->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
     m_pCommandBuffer->IASetInputLayout(m_pUIProgram->inputLayout);
+
     UINT offsets = 0;
-    m_pCommandBuffer->IASetVertexBuffers(0, 1, m_Quad.GetAddressOf(), &m_pUIProgram->vertexSize, &offsets);
+    ID3D11Buffer* pQuadBuffer = m_pQuad->getBuffer();
+
+    m_pCommandBuffer->IASetVertexBuffers(0, 1, &pQuadBuffer, &m_pUIProgram->vertexSize, &offsets);
 
     m_pCommandBuffer->VSSetShader(m_pUIProgram->vertexShader, nullptr, 0);
     m_pCommandBuffer->HSSetShader(m_pUIProgram->hullShader, nullptr, 0);

--- a/GameProject/Engine/UI/UIRenderer.hpp
+++ b/GameProject/Engine/UI/UIRenderer.hpp
@@ -8,6 +8,7 @@
 #include <d3d11.h>
 #include <wrl/client.h>
 
+class BufferDX11;
 class DeviceDX11;
 class ShaderHandler;
 class UIHandler;
@@ -35,7 +36,7 @@ private:
 
     Program* m_pUIProgram;
 
-    Microsoft::WRL::ComPtr<ID3D11Buffer> m_Quad;
+    BufferDX11* m_pQuad;
 
     /* Render targets */
     ID3D11RenderTargetView* m_pRenderTarget;

--- a/GameProject/Engine/Utils/EnumClass.hpp
+++ b/GameProject/Engine/Utils/EnumClass.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <type_traits>
+
+#define DECLARE_BITMASK(EnumClass)                                      \
+    EnumClass operator |(EnumClass lhs, EnumClass rhs)                  \
+    {                                                                   \
+        return static_cast<EnumClass> (                                 \
+            static_cast<std::underlying_type<EnumClass>::type>(lhs) |   \
+            static_cast<std::underlying_type<EnumClass>::type>(rhs)     \
+        );                                                              \
+    }                                                                   \
+    EnumClass operator &(EnumClass lhs, EnumClass rhs)                  \
+    {                                                                   \
+        return static_cast<EnumClass> (                                 \
+            static_cast<std::underlying_type<EnumClass>::type>(lhs) &   \
+            static_cast<std::underlying_type<EnumClass>::type>(rhs)     \
+        );                                                              \
+    }                                                                   \
+    EnumClass operator ^(EnumClass lhs, EnumClass rhs)                  \
+    {                                                                   \
+        return static_cast<EnumClass> (                                 \
+            static_cast<std::underlying_type<EnumClass>::type>(lhs) ^   \
+            static_cast<std::underlying_type<EnumClass>::type>(rhs)     \
+        );                                                              \
+    }                                                                   \
+    EnumClass operator ~(EnumClass rhs)                                 \
+    {                                                                   \
+        return static_cast<EnumClass> (                                 \
+            ~static_cast<std::underlying_type<EnumClass>::type>(rhs)    \
+        );                                                              \
+    }                                                                   \
+    EnumClass& operator |=(EnumClass &lhs, EnumClass rhs)               \
+    {                                                                   \
+        lhs = static_cast<EnumClass> (                                  \
+            static_cast<std::underlying_type<EnumClass>::type>(lhs) |   \
+            static_cast<std::underlying_type<EnumClass>::type>(rhs)     \
+        );                                                              \
+                                                                        \
+        return lhs;                                                     \
+    }                                                                   \
+    EnumClass& operator &=(EnumClass &lhs, EnumClass rhs)               \
+    {                                                                   \
+        lhs = static_cast<EnumClass> (                                  \
+            static_cast<std::underlying_type<EnumClass>::type>(lhs) &   \
+            static_cast<std::underlying_type<EnumClass>::type>(rhs)     \
+        );                                                              \
+                                                                        \
+        return lhs;                                                     \
+    }                                                                   \
+    EnumClass& operator ^=(EnumClass &lhs, EnumClass rhs)               \
+    {                                                                   \
+        lhs = static_cast<EnumClass> (                                  \
+            static_cast<std::underlying_type<EnumClass>::type>(lhs) ^   \
+            static_cast<std::underlying_type<EnumClass>::type>(rhs)     \
+        );                                                              \
+                                                                        \
+        return lhs;                                                     \
+    }
+
+// Check if the bitmask contains the flag
+#define HAS_FLAG(bitmask, flag) (flag == (bitmask & flag))

--- a/GameProject/Engine/Utils/EnumClass.hpp
+++ b/GameProject/Engine/Utils/EnumClass.hpp
@@ -2,7 +2,16 @@
 
 #include <type_traits>
 
-#define DECLARE_BITMASK(EnumClass)                                      \
+#define DECLARE_BITMASK(EnumClass)                          \
+    EnumClass operator |(EnumClass lhs, EnumClass rhs);     \
+    EnumClass operator &(EnumClass lhs, EnumClass rhs);     \
+    EnumClass operator ^(EnumClass lhs, EnumClass rhs);     \
+    EnumClass operator ~(EnumClass rhs);                    \
+    EnumClass& operator |=(EnumClass &lhs, EnumClass rhs);  \
+    EnumClass& operator &=(EnumClass &lhs, EnumClass rhs);  \
+    EnumClass& operator ^=(EnumClass &lhs, EnumClass rhs);
+
+#define DEFINE_BITMASK(EnumClass)                                       \
     EnumClass operator |(EnumClass lhs, EnumClass rhs)                  \
     {                                                                   \
         return static_cast<EnumClass> (                                 \
@@ -59,4 +68,4 @@
     }
 
 // Check if the bitmask contains the flag
-#define HAS_FLAG(bitmask, flag) (flag == (bitmask & flag))
+#define HAS_FLAG(bitmask, flag) (flag == ((bitmask) & (flag)))

--- a/GameProject/Game/Level/Tube.hpp
+++ b/GameProject/Game/Level/Tube.hpp
@@ -9,6 +9,7 @@
 struct Model;
 class ModelLoader;
 class ComponentSubscriber;
+class ShaderResourceHandler;
 class TextureLoader;
 
 struct TubePoint {
@@ -19,7 +20,7 @@ struct TubePoint {
 class TubeHandler : public ComponentHandler
 {
 public:
-    TubeHandler(ECSCore* pECS, ID3D11Device* device);
+    TubeHandler(ECSCore* pECS, ID3D11Device* pDevice);
     ~TubeHandler();
 
     virtual bool initHandler() override;
@@ -37,6 +38,7 @@ private:
     void createTubePoint(const std::vector<DirectX::XMFLOAT3>& sectionPoints, std::vector<TubePoint>& tubePoints, size_t pointIdx, float T);
 
 private:
+    ShaderResourceHandler* m_pShaderResourceHandler;
     TextureLoader* m_pTextureLoader;
     ID3D11Device* m_pDevice;
 

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -150,6 +150,8 @@
     <ClCompile Include="Engine\Physics\Velocity.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\DX11\BufferDX11.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\DX11\DeviceDX11.cpp" />
+    <ClCompile Include="Engine\Rendering\APIAbstractions\IBuffer.cpp" />
+    <ClCompile Include="Engine\Rendering\APIAbstractions\Shader.cpp" />
     <ClCompile Include="Engine\Rendering\AssetLoaders\AssetLoadersCore.cpp" />
     <ClCompile Include="Engine\Rendering\AssetLoaders\ModelLoader.cpp" />
     <ClCompile Include="Engine\Rendering\AssetLoaders\TextureLoader.cpp" />

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -148,6 +148,7 @@
     <ClCompile Include="Engine\InputHandler.cpp" />
     <ClCompile Include="Engine\Physics\PhysicsCore.cpp" />
     <ClCompile Include="Engine\Physics\Velocity.cpp" />
+    <ClCompile Include="Engine\Rendering\APIAbstractions\DX11\BufferDX11.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\DX11\DeviceDX11.cpp" />
     <ClCompile Include="Engine\Rendering\AssetLoaders\AssetLoadersCore.cpp" />
     <ClCompile Include="Engine\Rendering\AssetLoaders\ModelLoader.cpp" />
@@ -206,8 +207,11 @@
     <ClInclude Include="Engine\InputHandler.hpp" />
     <ClInclude Include="Engine\Physics\PhysicsCore.hpp" />
     <ClInclude Include="Engine\Physics\Velocity.hpp" />
+    <ClInclude Include="Engine\Rendering\APIAbstractions\DX11\BufferDX11.hpp" />
+    <ClInclude Include="Engine\Rendering\APIAbstractions\IBuffer.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\IDevice.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\DX11\DeviceDX11.hpp" />
+    <ClInclude Include="Engine\Rendering\APIAbstractions\Shader.hpp" />
     <ClInclude Include="Engine\Rendering\AssetContainers\AssetResources.hpp" />
     <ClInclude Include="Engine\Rendering\AssetContainers\Material.hpp" />
     <ClInclude Include="Engine\Rendering\AssetContainers\Model.hpp" />
@@ -234,6 +238,7 @@
     <ClInclude Include="Engine\UI\UIRenderer.hpp" />
     <ClInclude Include="Engine\Utils\DirectXUtils.hpp" />
     <ClInclude Include="Engine\Utils\ECSUtils.hpp" />
+    <ClInclude Include="Engine\Utils\EnumClass.hpp" />
     <ClInclude Include="Engine\Utils\GeneralUtils.hpp" />
     <ClInclude Include="Engine\Utils\IDContainer.hpp" />
     <ClInclude Include="Engine\Utils\IDGenerator.hpp" />


### PR DESCRIPTION
Implemented an abstraction of rendering buffers such as vertex buffers, index buffers and constant/uniform buffers.

Eventually, pointers to the API-independent interface class `IBuffer` will be used. To do so, the buffer creation process will have to be API-independent as well, eg. creating buffers through abstract `Device` pointers.