### PR TITLE
Move back buffer and depth buffer to abstract device

### DIFF
--- a/GameProject/Engine/ECS/Renderer.cpp
+++ b/GameProject/Engine/ECS/Renderer.cpp
@@ -5,7 +5,7 @@
 #include <Engine/Utils/DirectXUtils.hpp>
 #include <Engine/Utils/Logger.hpp>
 
-Renderer::Renderer(ECSCore* pECS, IDevice* pDevice)
+Renderer::Renderer(ECSCore* pECS, Device* pDevice)
     :m_pECS(pECS),
     m_pDevice(pDevice)
 {

--- a/GameProject/Engine/ECS/Renderer.hpp
+++ b/GameProject/Engine/ECS/Renderer.hpp
@@ -8,7 +8,7 @@
 
 class ComponentHandler;
 class ECSCore;
-class IDevice;
+class Device;
 class Renderer;
 
 struct RendererRegistration {
@@ -19,7 +19,7 @@ struct RendererRegistration {
 class Renderer
 {
 public:
-    Renderer(ECSCore* pECS, IDevice* pDevice);
+    Renderer(ECSCore* pECS, Device* pDevice);
     ~Renderer();
 
     virtual bool init() = 0;
@@ -33,7 +33,7 @@ protected:
     ComponentHandler* getComponentHandler(const std::type_index& handlerType);
 
 protected:
-    IDevice* m_pDevice;
+    Device* m_pDevice;
 
 private:
     ECSCore* m_pECS;

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
@@ -10,8 +10,6 @@ DeviceDX11::DeviceDX11()
     :m_pDevice(nullptr),
     m_pSwapChain(nullptr),
     m_pContext(nullptr),
-    m_pBackBuffer(nullptr),
-    m_pDepthTexture(nullptr),
     m_pDepthStencilState(nullptr),
     m_pBlendState(nullptr)
 {}
@@ -23,9 +21,6 @@ DeviceDX11::~DeviceDX11()
     SAFERELEASE(m_pContext)
     SAFERELEASE(m_pBlendState)
     SAFERELEASE(m_pDepthStencilState)
-
-    delete m_pBackBuffer;
-    delete m_pDepthTexture;
 }
 
 bool DeviceDX11::init(const SwapChainInfo& swapChainInfo, Window* pWindow)
@@ -39,8 +34,11 @@ bool DeviceDX11::init(const SwapChainInfo& swapChainInfo, Window* pWindow)
 
 void DeviceDX11::clearBackBuffer()
 {
-    m_pContext->ClearRenderTargetView(m_pBackBuffer->getRTV(), m_pClearColor);
-    m_pContext->ClearDepthStencilView(m_pDepthTexture->getDSV(), D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0, 0);
+    TextureDX11* pBackBuffer = reinterpret_cast<TextureDX11*>(m_pBackBuffer);
+    TextureDX11* pDepthTexture = reinterpret_cast<TextureDX11*>(m_pDepthTexture);
+
+    m_pContext->ClearRenderTargetView(pBackBuffer->getRTV(), m_pClearColor);
+    m_pContext->ClearDepthStencilView(pDepthTexture->getDSV(), D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0, 0);
 }
 
 void DeviceDX11::presentBackBuffer()
@@ -223,7 +221,8 @@ bool DeviceDX11::initBackBuffers(const SwapChainInfo& swapChainInfo, Window* pWi
         return false;
     }
 
-    m_pContext->ClearDepthStencilView(m_pDepthTexture->getDSV(), D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0, 0);
+    TextureDX11* pDepthTexture = reinterpret_cast<TextureDX11*>(m_pDepthTexture);
+    m_pContext->ClearDepthStencilView(pDepthTexture->getDSV(), D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0, 0);
 
     /* Set viewport */
     D3D11_VIEWPORT viewPort = {};

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
@@ -3,11 +3,11 @@
 #define NOMINMAX
 #include <Engine/Rendering/APIAbstractions/DX11/BufferDX11.hpp>
 #include <Engine/Rendering/APIAbstractions/DX11/TextureDX11.hpp>
-#include <Engine/Rendering/APIAbstractions/IDevice.hpp>
+#include <Engine/Rendering/APIAbstractions/Device.hpp>
 
 #include <d3d11.h>
 
-class DeviceDX11 : public IDevice
+class DeviceDX11 : public Device
 {
 public:
     DeviceDX11();
@@ -32,9 +32,6 @@ public:
     ID3D11Device* getDevice()           { return m_pDevice; }
     ID3D11DeviceContext* getContext()   { return m_pContext; }
 
-    Texture* getBackBuffer()    { return m_pBackBuffer; }
-    Texture* getDepthStencil()  { return m_pDepthTexture; }
-
 private:
     bool initDeviceAndSwapChain(const SwapChainInfo& swapChainInfo, Window* pWindow);
     bool initBackBuffers(const SwapChainInfo& swapChainInfo, Window* pWindow);
@@ -46,12 +43,9 @@ private:
 
     IDXGISwapChain* m_pSwapChain;
 
-    // Backbuffer textures
-    TextureDX11* m_pBackBuffer;
     // TODO: Remove this, each renderer should have its own blend state
     ID3D11BlendState* m_pBlendState;
 
-    TextureDX11* m_pDepthTexture;
     ID3D11DepthStencilState* m_pDepthStencilState;
 
     const FLOAT m_pClearColor[4] = {0.0f, 0.0f, 0.0f, 1.0f};

--- a/GameProject/Engine/Rendering/APIAbstractions/Device.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Device.cpp
@@ -1,0 +1,14 @@
+#include "Device.hpp"
+
+#include <Engine/Rendering/APIAbstractions/Texture.hpp>
+
+Device::Device()
+    :m_pBackBuffer(nullptr),
+    m_pDepthTexture(nullptr)
+{}
+
+Device::~Device()
+{
+    delete m_pBackBuffer;
+    delete m_pDepthTexture;
+}

--- a/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
@@ -20,9 +20,12 @@ struct BufferInfo;
 struct RasterizerStateInfo;
 struct TextureInfo;
 
-class IDevice
+class Device
 {
 public:
+    Device();
+    virtual ~Device();
+
     virtual bool init(const SwapChainInfo& swapChainInfo, Window* pWindow) = 0;
 
     virtual void clearBackBuffer() = 0;
@@ -38,4 +41,11 @@ public:
     virtual Texture* createTexture(const TextureInfo& textureInfo) = 0;
 
     virtual IRasterizerState* createRasterizerState(const RasterizerStateInfo& rasterizerInfo) = 0;
+
+    Texture* getBackBuffer()    { return m_pBackBuffer; }
+    Texture* getDepthStencil()  { return m_pDepthTexture; }
+
+protected:
+    Texture* m_pBackBuffer;
+    Texture* m_pDepthTexture;
 };

--- a/GameProject/Engine/Rendering/AssetLoaders/AssetLoadersCore.cpp
+++ b/GameProject/Engine/Rendering/AssetLoaders/AssetLoadersCore.cpp
@@ -1,6 +1,6 @@
 #include "AssetLoadersCore.hpp"
 
-AssetLoadersCore::AssetLoadersCore(ECSCore* pECS, IDevice* pDevice)
+AssetLoadersCore::AssetLoadersCore(ECSCore* pECS, Device* pDevice)
     :m_TextureLoader(pECS, pDevice),
     m_ModelLoader(pECS, &m_TextureLoader, reinterpret_cast<DeviceDX11*>(pDevice))
 {}

--- a/GameProject/Engine/Rendering/AssetLoaders/AssetLoadersCore.hpp
+++ b/GameProject/Engine/Rendering/AssetLoaders/AssetLoadersCore.hpp
@@ -4,12 +4,12 @@
 #include <Engine/Rendering/AssetLoaders/ModelLoader.hpp>
 
 class ECSCore;
-class IDevice;
+class Device;
 
 class AssetLoadersCore
 {
 public:
-    AssetLoadersCore(ECSCore* pECS, IDevice* pDevice);
+    AssetLoadersCore(ECSCore* pECS, Device* pDevice);
     ~AssetLoadersCore();
 
 private:

--- a/GameProject/Engine/Rendering/AssetLoaders/TextureLoader.cpp
+++ b/GameProject/Engine/Rendering/AssetLoaders/TextureLoader.cpp
@@ -1,11 +1,11 @@
 #include "TextureLoader.hpp"
 
-#include <Engine/Rendering/APIAbstractions/IDevice.hpp>
+#include <Engine/Rendering/APIAbstractions/Device.hpp>
 #include <Engine/Rendering/APIAbstractions/Texture.hpp>
 #include <Engine/Utils/ECSUtils.hpp>
 #include <Engine/Utils/Logger.hpp>
 
-TextureLoader::TextureLoader(ECSCore* pECS, IDevice* pDevice)
+TextureLoader::TextureLoader(ECSCore* pECS, Device* pDevice)
     :ComponentHandler(pECS, TID(TextureLoader)),
     m_pDevice(pDevice)
 {

--- a/GameProject/Engine/Rendering/AssetLoaders/TextureLoader.hpp
+++ b/GameProject/Engine/Rendering/AssetLoaders/TextureLoader.hpp
@@ -4,13 +4,13 @@
 
 #include <unordered_map>
 
-class IDevice;
+class Device;
 class Texture;
 
 class TextureLoader : public ComponentHandler
 {
 public:
-    TextureLoader(ECSCore* pECS, IDevice* pDevice);
+    TextureLoader(ECSCore* pECS, Device* pDevice);
     ~TextureLoader() = default;
 
     virtual bool initHandler() override;
@@ -20,5 +20,5 @@ public:
 private:
     std::unordered_map<std::string, std::weak_ptr<Texture>> m_Textures;
 
-    IDevice* m_pDevice;
+    Device* m_pDevice;
 };

--- a/GameProject/Engine/Rendering/MeshRenderer.cpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.cpp
@@ -1,10 +1,10 @@
 #include "MeshRenderer.hpp"
 
+#include <Engine/Rendering/APIAbstractions/Device.hpp>
 #include <Engine/Rendering/APIAbstractions/DX11/BufferDX11.hpp>
 #include <Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp>
-#include <Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp>
-#include <Engine/Rendering/AssetContainers/Material.hpp>
 #include <Engine/Rendering/APIAbstractions/IRasterizerState.hpp>
+#include <Engine/Rendering/AssetContainers/Material.hpp>
 #include <Engine/Rendering/AssetContainers/Model.hpp>
 #include <Engine/Rendering/Components/ComponentGroups.hpp>
 #include <Engine/Rendering/Components/VPMatrices.hpp>
@@ -17,7 +17,7 @@
 
 #include <DirectXMath.h>
 
-MeshRenderer::MeshRenderer(ECSCore* pECS, DeviceDX11* pDevice, Window* pWindow)
+MeshRenderer::MeshRenderer(ECSCore* pECS, Device* pDevice, Window* pWindow)
     :Renderer(pECS, pDevice),
     m_pCommandList(nullptr),
     m_pRasterizerState(nullptr),

--- a/GameProject/Engine/Rendering/MeshRenderer.hpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.hpp
@@ -10,7 +10,7 @@
 
 class IBuffer;
 class ICommandList;
-class DeviceDX11;
+class Device;
 class IRasterizerState;
 class RenderableHandler;
 class Texture;
@@ -21,7 +21,7 @@ class Window;
 class MeshRenderer : public Renderer
 {
 public:
-    MeshRenderer(ECSCore* pECS, DeviceDX11* pDevice, Window* pWindow);
+    MeshRenderer(ECSCore* pECS, Device* pDevice, Window* pWindow);
     ~MeshRenderer();
 
     bool init() override final;

--- a/GameProject/Engine/Rendering/RenderingCore.cpp
+++ b/GameProject/Engine/Rendering/RenderingCore.cpp
@@ -2,7 +2,7 @@
 
 #include <Engine/Rendering/Window.hpp>
 
-RenderingCore::RenderingCore(ECSCore* pECS, IDevice* pDevice, Window* pWindow)
+RenderingCore::RenderingCore(ECSCore* pECS, Device* pDevice, Window* pWindow)
     :m_VPHandler(pECS),
     m_ShaderHandler(pDevice, pECS),
     m_ShaderResourceHandler(pECS, pDevice),

--- a/GameProject/Engine/Rendering/RenderingCore.hpp
+++ b/GameProject/Engine/Rendering/RenderingCore.hpp
@@ -12,7 +12,7 @@ class Window;
 class RenderingCore
 {
 public:
-    RenderingCore(ECSCore* pECS, IDevice* pDevice, Window* pWindow);
+    RenderingCore(ECSCore* pECS, Device* pDevice, Window* pWindow);
     ~RenderingCore();
 
 private:

--- a/GameProject/Engine/Rendering/RenderingHandler.cpp
+++ b/GameProject/Engine/Rendering/RenderingHandler.cpp
@@ -6,7 +6,7 @@
 
 #include <thread>
 
-RenderingHandler::RenderingHandler(ECSCore* pECS, DeviceDX11* pDevice, Window* pWindow)
+RenderingHandler::RenderingHandler(ECSCore* pECS, Device* pDevice, Window* pWindow)
     :m_pECS(pECS),
     m_pDevice(pDevice),
     m_MeshRenderer(pECS, pDevice, pWindow),

--- a/GameProject/Engine/Rendering/RenderingHandler.hpp
+++ b/GameProject/Engine/Rendering/RenderingHandler.hpp
@@ -6,7 +6,7 @@
 class RenderingHandler
 {
 public:
-    RenderingHandler(ECSCore* pECS, DeviceDX11* pDevice, Window* pWindow);
+    RenderingHandler(ECSCore* pECS, Device* pDevice, Window* pWindow);
     ~RenderingHandler();
 
     bool init();
@@ -19,7 +19,7 @@ private:
 
 private:
     ECSCore* m_pECS;
-    IDevice* m_pDevice;
+    Device* m_pDevice;
 
     std::vector<Renderer*> m_Renderers;
 

--- a/GameProject/Engine/Rendering/ShaderHandler.cpp
+++ b/GameProject/Engine/Rendering/ShaderHandler.cpp
@@ -7,7 +7,7 @@
 
 #include <d3dcompiler.h>
 
-ShaderHandler::ShaderHandler(IDevice* pDevice, ECSCore* pECS)
+ShaderHandler::ShaderHandler(Device* pDevice, ECSCore* pECS)
     :ComponentHandler(pECS, TID(ShaderHandler)),
     m_pDevice(pDevice)
 {

--- a/GameProject/Engine/Rendering/ShaderHandler.hpp
+++ b/GameProject/Engine/Rendering/ShaderHandler.hpp
@@ -32,12 +32,12 @@ struct Program {
     ID3D11PixelShader* pixelShader;
 };
 
-class IDevice;
+class Device;
 
 class ShaderHandler : public ComponentHandler
 {
 public:
-    ShaderHandler(IDevice* pDevice, ECSCore* pECS);
+    ShaderHandler(Device* pDevice, ECSCore* pECS);
     ~ShaderHandler();
 
     virtual bool initHandler() override;
@@ -51,5 +51,5 @@ private:
 
     std::vector<Program> m_Programs;
 
-    IDevice* m_pDevice;
+    Device* m_pDevice;
 };

--- a/GameProject/Engine/Rendering/ShaderResourceHandler.cpp
+++ b/GameProject/Engine/Rendering/ShaderResourceHandler.cpp
@@ -7,7 +7,7 @@
 #include <Engine/Utils/ECSUtils.hpp>
 #include <Engine/Utils/Logger.hpp>
 
-ShaderResourceHandler::ShaderResourceHandler(ECSCore* pECS, IDevice* pDevice)
+ShaderResourceHandler::ShaderResourceHandler(ECSCore* pECS, Device* pDevice)
     :ComponentHandler(pECS, TID(ShaderResourceHandler)),
     m_pDevice(pDevice),
     m_pQuadVertices(nullptr)

--- a/GameProject/Engine/Rendering/ShaderResourceHandler.hpp
+++ b/GameProject/Engine/Rendering/ShaderResourceHandler.hpp
@@ -7,13 +7,13 @@
 #include <wrl/client.h>
 
 class BufferDX11;
-class IDevice;
+class Device;
 struct Vertex;
 
 class ShaderResourceHandler : public ComponentHandler
 {
 public:
-    ShaderResourceHandler(ECSCore* pECS, IDevice* pDevice);
+    ShaderResourceHandler(ECSCore* pECS, Device* pDevice);
     ~ShaderResourceHandler();
 
     virtual bool initHandler() override;
@@ -23,7 +23,7 @@ public:
     BufferDX11* getQuarterScreenQuad();
 
 private:
-    IDevice* m_pDevice;
+    Device* m_pDevice;
 
     /* Samplers */
     Microsoft::WRL::ComPtr<ID3D11SamplerState> aniSampler;

--- a/GameProject/Engine/Rendering/Text/TextRenderer.cpp
+++ b/GameProject/Engine/Rendering/Text/TextRenderer.cpp
@@ -12,7 +12,7 @@
 
 #include <algorithm>
 
-TextRenderer::TextRenderer(ECSCore* pECS, IDevice* pDevice)
+TextRenderer::TextRenderer(ECSCore* pECS, Device* pDevice)
     :ComponentHandler(pECS, TID(TextRenderer)),
     m_pDevice(pDevice)
 {

--- a/GameProject/Engine/Rendering/Text/TextRenderer.hpp
+++ b/GameProject/Engine/Rendering/Text/TextRenderer.hpp
@@ -27,12 +27,12 @@ struct ProcessedGlyph {
     Bytemap bytemap;
 };
 
-class IDevice;
+class Device;
 
 class TextRenderer : public ComponentHandler
 {
 public:
-    TextRenderer(ECSCore* pECS, IDevice* pDevice);
+    TextRenderer(ECSCore* pECS, Device* pDevice);
     ~TextRenderer();
 
     virtual bool initHandler() override;
@@ -57,7 +57,7 @@ private:
     void bitmapToBytemap(const FT_Bitmap& bitmap, Bytemap& bytemap);
 
 private:
-    IDevice* m_pDevice;
+    Device* m_pDevice;
 
     // Rendering text results in a texture and a texture reference being created. This is the storage for the textures.
     std::vector<std::weak_ptr<Texture>> m_Textures;

--- a/GameProject/Engine/UI/Panel.cpp
+++ b/GameProject/Engine/UI/Panel.cpp
@@ -12,7 +12,7 @@
 #include <Engine/Utils/ECSUtils.hpp>
 #include <Engine/Utils/Logger.hpp>
 
-UIHandler::UIHandler(ECSCore* pECS, IDevice* pDevice, Window* pWindow)
+UIHandler::UIHandler(ECSCore* pECS, Device* pDevice, Window* pWindow)
     :ComponentHandler(pECS, TID(UIHandler)),
     m_ClientWidth(pWindow->getWidth()),
     m_ClientHeight(pWindow->getHeight()),

--- a/GameProject/Engine/UI/Panel.hpp
+++ b/GameProject/Engine/UI/Panel.hpp
@@ -72,7 +72,7 @@ class BufferDX11;
 class Display;
 class IBuffer;
 class ICommandList;
-class IDevice;
+class Device;
 class IRasterizerState;
 class Window;
 struct Program;
@@ -80,7 +80,7 @@ struct Program;
 class UIHandler : public ComponentHandler
 {
 public:
-    UIHandler(ECSCore* pECS, IDevice* pDevice, Window* pWindow);
+    UIHandler(ECSCore* pECS, Device* pDevice, Window* pWindow);
     ~UIHandler();
 
     virtual bool initHandler() override;
@@ -101,7 +101,7 @@ private:
     void renderTexturesOntoPanel(std::vector<TextureAttachment>& attachments, UIPanel& panel);
 
 private:
-    IDevice* m_pDevice;
+    Device* m_pDevice;
     ICommandList* m_pCommandList;
 
     Program* m_pUIProgram;

--- a/GameProject/Engine/UI/UICore.cpp
+++ b/GameProject/Engine/UI/UICore.cpp
@@ -2,7 +2,7 @@
 
 #include <Engine/Rendering/Window.hpp>
 
-UICore::UICore(ECSCore* pECS, IDevice* pDevice, Window* pWindow)
+UICore::UICore(ECSCore* pECS, Device* pDevice, Window* pWindow)
     :m_PanelHandler(pECS, pDevice, pWindow),
     m_TextRenderer(pECS, pDevice),
     m_ButtonSystem(pECS, pWindow)

--- a/GameProject/Engine/UI/UICore.hpp
+++ b/GameProject/Engine/UI/UICore.hpp
@@ -4,13 +4,13 @@
 #include <Engine/UI/ButtonSystem.hpp>
 #include <Engine/Rendering/Text/TextRenderer.hpp>
 
-class IDevice;
+class Device;
 class Window;
 
 class UICore
 {
 public:
-    UICore(ECSCore* pECS, IDevice* pDevice, Window* pWindow);
+    UICore(ECSCore* pECS, Device* pDevice, Window* pWindow);
     ~UICore();
 
     ButtonSystem& getButtonSystem() { return m_ButtonSystem; }

--- a/GameProject/Engine/UI/UIRenderer.cpp
+++ b/GameProject/Engine/UI/UIRenderer.cpp
@@ -1,7 +1,7 @@
 #include "UIRenderer.hpp"
 
+#include <Engine/Rendering/APIAbstractions/Device.hpp>
 #include <Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp>
-#include <Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp>
 #include <Engine/Rendering/APIAbstractions/IRasterizerState.hpp>
 #include <Engine/Rendering/AssetContainers/Model.hpp>
 #include <Engine/Rendering/ShaderResourceHandler.hpp>
@@ -12,7 +12,7 @@
 #include <Engine/Utils/ECSUtils.hpp>
 #include <Engine/Utils/Logger.hpp>
 
-UIRenderer::UIRenderer(ECSCore* pECS, DeviceDX11* pDevice, Window* pWindow)
+UIRenderer::UIRenderer(ECSCore* pECS, Device* pDevice, Window* pWindow)
     :Renderer(pECS, pDevice),
     m_pCommandList(nullptr),
     m_pRenderTarget(pDevice->getBackBuffer()),

--- a/GameProject/Engine/UI/UIRenderer.hpp
+++ b/GameProject/Engine/UI/UIRenderer.hpp
@@ -7,7 +7,7 @@
 
 #include <d3d11.h>
 
-class DeviceDX11;
+class Device;
 class IBuffer;
 class ICommandList;
 class IRasterizerState;
@@ -20,7 +20,7 @@ struct Program;
 class UIRenderer : public Renderer
 {
 public:
-    UIRenderer(ECSCore* pECS, DeviceDX11* pDevice, Window* pWindow);
+    UIRenderer(ECSCore* pECS, Device* pDevice, Window* pWindow);
     ~UIRenderer();
 
     bool init() override final;

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -148,6 +148,7 @@
     <ClCompile Include="Engine\InputHandler.cpp" />
     <ClCompile Include="Engine\Physics\PhysicsCore.cpp" />
     <ClCompile Include="Engine\Physics\Velocity.cpp" />
+    <ClCompile Include="Engine\Rendering\APIAbstractions\Device.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\DX11\BufferDX11.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\DX11\CommandListDX11.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\DX11\DeviceDX11.cpp" />
@@ -216,7 +217,7 @@
     <ClInclude Include="Engine\Rendering\APIAbstractions\DX11\TextureDX11.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\IBuffer.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\ICommandList.hpp" />
-    <ClInclude Include="Engine\Rendering\APIAbstractions\IDevice.hpp" />
+    <ClInclude Include="Engine\Rendering\APIAbstractions\Device.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\DX11\DeviceDX11.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\IRasterizerState.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\Shader.hpp" />


### PR DESCRIPTION
Increasing the use of abstract objects, as opposed to API-specific ones.