### PR TITLE
DX11 texture layout conversion

### DIFF
--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.cpp
@@ -21,6 +21,7 @@
 CommandListDX11::CommandListDX11(ID3D11DeviceContext* pImmediateContext, ID3D11Device* pDevice)
     :m_pContext(nullptr),
     m_pImmediateContext(pImmediateContext),
+    m_pDevice(pDevice),
     m_pBoundPipeline(nullptr)
 {
     HRESULT hr = pDevice->CreateDeferredContext(0, &m_pContext);
@@ -112,5 +113,6 @@ void CommandListDX11::drawIndexed(size_t indexCount)
 
 void CommandListDX11::convertTextureLayout(TEXTURE_LAYOUT oldLayout, TEXTURE_LAYOUT newLayout, Texture* pTexture)
 {
-    pTexture->convertTextureLayout(oldLayout, newLayout);
+    TextureDX11* pTextureDX = reinterpret_cast<TextureDX11*>(pTexture);
+    pTextureDX->convertTextureLayout(m_pContext, m_pDevice, oldLayout, newLayout);
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp
@@ -41,5 +41,7 @@ private:
     ID3D11DeviceContext* m_pContext;
     ID3D11DeviceContext* m_pImmediateContext;
 
+    ID3D11Device* m_pDevice;
+
     PipelineDX11* m_pBoundPipeline;
 };

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceCreatorDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceCreatorDX11.cpp
@@ -103,10 +103,16 @@ bool DeviceCreatorDX11::initBackBuffers(const SwapchainInfo& swapChainInfo, cons
 
     D3D11_TEXTURE2D_DESC backbufferDesc = {};
     pBackBuffer->GetDesc(&backbufferDesc);
-    m_pBackBuffer = DBG_NEW TextureDX11({(uint32_t)backbufferDesc.Width, (uint32_t)backbufferDesc.Height}, convertFormatFromDX(backbufferDesc.Format), nullptr, nullptr, pBackBufferRTV, nullptr);
+
+    TextureInfoDX11 textureInfoDX = {};
+    textureInfoDX.Dimensions  = {(uint32_t)backbufferDesc.Width, (uint32_t)backbufferDesc.Height};
+    textureInfoDX.Format      = convertFormatFromDX(backbufferDesc.Format);
+    textureInfoDX.LayoutFlags = TextureDX11::convertBindFlags(backbufferDesc.BindFlags);
+    textureInfoDX.pRTV        = pBackBufferRTV;
+    m_pBackBuffer = DBG_NEW TextureDX11(textureInfoDX);
 
     /* Depth stencil */
-    TextureInfo textureInfo = {};
+    TextureInfo textureInfo     = {};
     textureInfo.Dimensions      = {pWindow->getWidth(), pWindow->getHeight()};
     textureInfo.Format          = RESOURCE_FORMAT::D32_FLOAT;
     textureInfo.InitialLayout   = TEXTURE_LAYOUT::DEPTH_ATTACHMENT;

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/TextureDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/TextureDX11.cpp
@@ -33,7 +33,16 @@ TextureDX11* TextureDX11::createFromFile(const std::string& filePath, ID3D11Devi
 
     SAFERELEASE(pTextureResource)
 
-    return DBG_NEW TextureDX11(dimensions, convertFormatFromDX(txDesc.Format), pSRV, nullptr, nullptr, nullptr);
+    TextureInfoDX11 textureInfoDX = {};
+    textureInfoDX.Dimensions    = {(uint32_t)txDesc.Width, (uint32_t)txDesc.Height};
+    textureInfoDX.Format        = convertFormatFromDX(txDesc.Format);
+    textureInfoDX.LayoutFlags   = convertBindFlags(txDesc.BindFlags);
+    textureInfoDX.pSRV          = pSRV;
+    textureInfoDX.pDSV          = nullptr;
+    textureInfoDX.pRTV          = nullptr;
+    textureInfoDX.pUAV          = nullptr;
+
+    return DBG_NEW TextureDX11(textureInfoDX);
 }
 
 TextureDX11* TextureDX11::create(const TextureInfo& textureInfo, ID3D11Device* pDevice)
@@ -47,7 +56,7 @@ TextureDX11* TextureDX11::create(const TextureInfo& textureInfo, ID3D11Device* p
     txDesc.SampleDesc.Count     = 1;
     txDesc.SampleDesc.Quality   = 0;
     txDesc.Usage                = D3D11_USAGE_DEFAULT;
-    txDesc.BindFlags            = TextureDX11::convertBindFlags(textureInfo.LayoutFlags);
+    txDesc.BindFlags            = TextureDX11::convertLayoutFlags(textureInfo.LayoutFlags);
     txDesc.CPUAccessFlags       = 0;
     txDesc.MiscFlags            = 0;
 
@@ -95,15 +104,25 @@ TextureDX11* TextureDX11::create(const TextureInfo& textureInfo, ID3D11Device* p
         }
     }
 
-    return DBG_NEW TextureDX11(textureInfo.Dimensions, textureInfo.Format, pSRV, pDSV, pRTV, nullptr);
+    TextureInfoDX11 textureInfoDX = {};
+    textureInfoDX.Dimensions    = textureInfo.Dimensions;
+    textureInfoDX.Format        = textureInfo.Format;
+    textureInfoDX.LayoutFlags   = textureInfo.LayoutFlags;
+    textureInfoDX.pSRV          = pSRV;
+    textureInfoDX.pDSV          = pDSV;
+    textureInfoDX.pRTV          = pRTV;
+    textureInfoDX.pUAV          = nullptr;
+
+    return DBG_NEW TextureDX11(textureInfoDX);
 }
 
-TextureDX11::TextureDX11(const glm::uvec2& dimensions, RESOURCE_FORMAT format, ID3D11ShaderResourceView* pSRV, ID3D11DepthStencilView* pDSV, ID3D11RenderTargetView* pRTV, ID3D11UnorderedAccessView* pUAV)
-    :Texture(dimensions, format),
-    m_pSRV(pSRV),
-    m_pDSV(pDSV),
-    m_pRTV(pRTV),
-    m_pUAV(pUAV)
+TextureDX11::TextureDX11(const TextureInfoDX11& textureInfo)
+    :Texture(textureInfo.Dimensions, textureInfo.Format),
+    m_pSRV(textureInfo.pSRV),
+    m_pDSV(textureInfo.pDSV),
+    m_pRTV(textureInfo.pRTV),
+    m_pUAV(textureInfo.pUAV),
+    m_LayoutFlags(textureInfo.LayoutFlags)
 {}
 
 TextureDX11::~TextureDX11()
@@ -114,12 +133,81 @@ TextureDX11::~TextureDX11()
     SAFERELEASE(m_pUAV)
 }
 
-void TextureDX11::convertTextureLayout(TEXTURE_LAYOUT oldLayout, TEXTURE_LAYOUT newLayout)
+void TextureDX11::convertTextureLayout(ID3D11DeviceContext* pContext, ID3D11Device* pDevice, TEXTURE_LAYOUT oldLayout, TEXTURE_LAYOUT newLayout)
 {
-    // TODO
+    if (HAS_FLAG(m_LayoutFlags, newLayout)) {
+        return;
+    }
+
+    // Create a new texture with the old and the new bind flags combined
+    m_LayoutFlags = oldLayout | newLayout;
+
+    // Get resource pointer
+    ID3D11Resource* pResource = nullptr;
+    if (m_pSRV) {
+        m_pSRV->GetResource(&pResource);
+    } else if (m_pDSV) {
+        m_pDSV->GetResource(&pResource);
+    } else if (m_pRTV) {
+        m_pRTV->GetResource(&pResource);
+    } else if (m_pUAV) {
+        m_pUAV->GetResource(&pResource);
+    }
+
+    // Get old texture description and only change the bind flags
+    D3D11_TEXTURE2D_DESC txDesc = {};
+    reinterpret_cast<ID3D11Texture2D*>(pResource)->GetDesc(&txDesc);
+    txDesc.BindFlags = convertLayoutFlags(m_LayoutFlags);
+
+    ID3D11Texture2D* pNewTexture = nullptr;
+    HRESULT hr = pDevice->CreateTexture2D(&txDesc, nullptr, &pNewTexture);
+    if (FAILED(hr)) {
+        LOG_WARNING("Failed to create new texture whilst converting texture layout: %s", hresultToString(hr).c_str());
+        return;
+    }
+
+    pContext->CopyResource(pResource, pNewTexture);
+
+    // Create new texture view, the type depends on the new layout flag
+    hr = S_OK;
+
+    switch (newLayout) {
+        case TEXTURE_LAYOUT::SHADER_READ_ONLY:
+            hr = pDevice->CreateShaderResourceView(pNewTexture, nullptr, &m_pSRV);
+            break;
+        case TEXTURE_LAYOUT::DEPTH_ATTACHMENT:
+            hr = pDevice->CreateDepthStencilView(pNewTexture, nullptr, &m_pDSV);
+            break;
+        case TEXTURE_LAYOUT::RENDER_TARGET:
+            hr = pDevice->CreateRenderTargetView(pNewTexture, nullptr, &m_pRTV);
+            break;
+        // TODO: UAV support
+    }
+
+    if (FAILED(hr)) {
+        LOG_WARNING("Failed to create new texture view after conversion, old and new layouts: %d -> %d", (int)oldLayout, (int)newLayout);
+    }
 }
 
-UINT TextureDX11::convertBindFlags(TEXTURE_LAYOUT layoutFlags)
+TEXTURE_LAYOUT TextureDX11::convertBindFlags(UINT bindFlags)
+{
+    TEXTURE_LAYOUT layoutFlags = {};
+    if (HAS_FLAG(bindFlags, D3D11_BIND_SHADER_RESOURCE)) {
+        layoutFlags |= TEXTURE_LAYOUT::SHADER_READ_ONLY;
+    }
+
+    if (HAS_FLAG(bindFlags, D3D11_BIND_RENDER_TARGET)) {
+        layoutFlags |= TEXTURE_LAYOUT::RENDER_TARGET;
+    }
+
+    if (HAS_FLAG(bindFlags, D3D11_BIND_DEPTH_STENCIL)) {
+        layoutFlags |= TEXTURE_LAYOUT::DEPTH_ATTACHMENT;
+    }
+
+    return layoutFlags;
+}
+
+UINT TextureDX11::convertLayoutFlags(TEXTURE_LAYOUT layoutFlags)
 {
     return
         HAS_FLAG(layoutFlags, TEXTURE_LAYOUT::SHADER_READ_ONLY) * D3D11_BIND_SHADER_RESOURCE |

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/TextureDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/TextureDX11.hpp
@@ -6,6 +6,16 @@
 #include <d3d11.h>
 #include <string>
 
+struct TextureInfoDX11 {
+    glm::uvec2 Dimensions;
+    RESOURCE_FORMAT Format;
+    TEXTURE_LAYOUT LayoutFlags;
+    ID3D11ShaderResourceView* pSRV;
+    ID3D11DepthStencilView* pDSV;
+    ID3D11RenderTargetView* pRTV;
+    ID3D11UnorderedAccessView* pUAV;
+};
+
 class TextureDX11 : public Texture
 {
 public:
@@ -14,21 +24,25 @@ public:
     static TextureDX11* create(const TextureInfo& textureInfo, ID3D11Device* pDevice);
 
 public:
-    TextureDX11(const glm::uvec2& dimensions, RESOURCE_FORMAT format, ID3D11ShaderResourceView* pSRV, ID3D11DepthStencilView* pDSV, ID3D11RenderTargetView* pRTV, ID3D11UnorderedAccessView* pUAV);
+    TextureDX11(const TextureInfoDX11& textureInfo);
     ~TextureDX11();
 
-    void convertTextureLayout(TEXTURE_LAYOUT oldLayout, TEXTURE_LAYOUT newLayout) override final;
+    void convertTextureLayout(ID3D11DeviceContext* pContext, ID3D11Device* pDevice, TEXTURE_LAYOUT oldLayout, TEXTURE_LAYOUT newLayout);
 
     ID3D11ShaderResourceView* getSRV() const    { return m_pSRV; }
     ID3D11RenderTargetView* getRTV() const      { return m_pRTV; }
     ID3D11DepthStencilView* getDSV() const      { return m_pDSV; }
 
+    static TEXTURE_LAYOUT convertBindFlags(UINT bindFlags);
+
 private:
-    static UINT convertBindFlags(TEXTURE_LAYOUT layoutFlags);
+    static UINT convertLayoutFlags(TEXTURE_LAYOUT layoutFlags);
 
 private:
     ID3D11ShaderResourceView* m_pSRV;
     ID3D11DepthStencilView* m_pDSV;
     ID3D11RenderTargetView* m_pRTV;
     ID3D11UnorderedAccessView* m_pUAV;
+
+    TEXTURE_LAYOUT m_LayoutFlags;
 };

--- a/GameProject/Engine/Rendering/APIAbstractions/Texture.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Texture.hpp
@@ -36,8 +36,6 @@ public:
     const glm::uvec2& getDimensions() const { return m_Dimensions; }
     inline RESOURCE_FORMAT getFormat() const { return m_Format; }
 
-    virtual void convertTextureLayout(TEXTURE_LAYOUT oldLayout, TEXTURE_LAYOUT newLayout) = 0;
-
 protected:
     glm::uvec2 m_Dimensions;
     RESOURCE_FORMAT m_Format;


### PR DESCRIPTION
If the API user doesn't predict all layouts a texture will use at texture creation, a 'layout conversion' will have to take place at some point.

During a layout conversion, the DX11 API implementation will have to create a new texture with the old and new bind/layout flags combined, and copy the old texture data into the new one.