### PR TITLE
Move map and unmap to device

### DIFF
--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.cpp
@@ -88,20 +88,6 @@ void CommandListDX11::bindDescriptorSet(DescriptorSet* pDescriptorSet)
     pDescriptorSetDX->bind(m_pContext);
 }
 
-void CommandListDX11::map(IBuffer* pBuffer, void** ppMappedMemory)
-{
-    ID3D11Buffer* pBufferDX = reinterpret_cast<BufferDX11*>(pBuffer)->getBuffer();
-
-    D3D11_MAPPED_SUBRESOURCE mappedResources = {};
-    m_pContext->Map(pBufferDX, 0u, D3D11_MAP_WRITE_DISCARD, 0u, &mappedResources);
-    (*ppMappedMemory) = mappedResources.pData;
-}
-
-void CommandListDX11::unmap(IBuffer* pBuffer)
-{
-    m_pContext->Unmap(reinterpret_cast<BufferDX11*>(pBuffer)->getBuffer(), 0u);
-}
-
 void CommandListDX11::bindVertexBuffer(uint32_t firstBinding, IBuffer* pBuffer)
 {
     ID3D11Buffer* pBufferDX = reinterpret_cast<BufferDX11*>(pBuffer)->getBuffer();

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp
@@ -28,9 +28,6 @@ public:
     // Shader resources
     void bindDescriptorSet(DescriptorSet* pDescriptorSet) override final;
 
-    void map(IBuffer* pBuffer, void** ppMappedMemory);
-    void unmap(IBuffer* pBuffer);
-
     void bindVertexBuffer(uint32_t firstBinding, IBuffer* pBuffer) override final;
     void bindIndexBuffer(IBuffer* pBuffer) override final;
 

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
@@ -76,6 +76,20 @@ PipelineDX11* DeviceDX11::createPipeline(const PipelineInfo& pipelineInfo)
     return PipelineDX11::create(pipelineInfo, this);
 }
 
+void DeviceDX11::map(IBuffer* pBuffer, void** ppMappedMemory)
+{
+    ID3D11Buffer* pBufferDX = reinterpret_cast<BufferDX11*>(pBuffer)->getBuffer();
+
+    D3D11_MAPPED_SUBRESOURCE mappedResources = {};
+    m_pContext->Map(pBufferDX, 0u, D3D11_MAP_WRITE_DISCARD, 0u, &mappedResources);
+    (*ppMappedMemory) = mappedResources.pData;
+}
+
+void DeviceDX11::unmap(IBuffer* pBuffer)
+{
+    m_pContext->Unmap(reinterpret_cast<BufferDX11*>(pBuffer)->getBuffer(), 0u);
+}
+
 BufferDX11* DeviceDX11::createBuffer(const BufferInfo& bufferInfo, StagingResources* pStagingResources)
 {
     BufferDX11* pBuffer = DBG_NEW BufferDX11(m_pDevice, bufferInfo);

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
@@ -47,6 +47,9 @@ public:
     PipelineDX11* createPipeline(const PipelineInfo& pipelineInfo) override final;
     PipelineLayoutDX11* createPipelineLayout(std::vector<IDescriptorSetLayout*> descriptorSetLayout) override final { return DBG_NEW PipelineLayoutDX11(); }
 
+    void map(IBuffer* pBuffer, void** ppMappedMemory) override final;
+    void unmap(IBuffer* pBuffer) override final;
+
     // Shader resources
     BufferDX11* createBuffer(const BufferInfo& bufferInfo, StagingResources* pStagingResources = nullptr) override final;
     BufferDX11* createVertexBuffer(const void* pVertices, size_t vertexSize, size_t vertexCount) override final;

--- a/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
@@ -80,6 +80,9 @@ public:
     virtual IPipelineLayout* createPipelineLayout(std::vector<IDescriptorSetLayout*> descriptorSetLayout) = 0;
     virtual IPipeline* createPipeline(const PipelineInfo& pipelineInfo) = 0;
 
+    virtual void map(IBuffer* pBuffer, void** ppMappedMemory) = 0;
+    virtual void unmap(IBuffer* pBuffer) = 0;
+
     // Shader resources
     // pStagingResources is only needed if the buffer has initial data and is not CPU-writable
     virtual IBuffer* createBuffer(const BufferInfo& bufferInfo, StagingResources* pStagingResources = nullptr) = 0;

--- a/GameProject/Engine/Rendering/APIAbstractions/ICommandList.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/ICommandList.hpp
@@ -47,9 +47,6 @@ public:
     // Shader resources
     virtual void bindDescriptorSet(DescriptorSet* pDescriptorSet) = 0;
 
-    virtual void map(IBuffer* pBuffer, void** ppMappedMemory) = 0;
-    virtual void unmap(IBuffer* pBuffer) = 0;
-
     virtual void bindVertexBuffer(uint32_t firstBinding, IBuffer* pBuffer) = 0;
     virtual void bindIndexBuffer(IBuffer* pBuffer) = 0;
 

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/BufferVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/BufferVK.cpp
@@ -62,6 +62,13 @@ BufferVK::~BufferVK()
     vkDestroyBuffer(m_pDevice->getDevice(), m_Buffer, nullptr);
 }
 
+VmaAllocationInfo BufferVK::getAllocationInfo() const
+{
+    VmaAllocationInfo allocationInfo = {};
+    vmaGetAllocationInfo(m_pDevice->getVulkanAllocator(), m_Allocation, &allocationInfo);
+    return allocationInfo;
+}
+
 VkBufferCreateInfo BufferVK::convertBufferInfo(const BufferInfo& bufferInfo)
 {
     VkBufferCreateInfo createInfo = {};
@@ -130,11 +137,10 @@ VmaAllocationCreateInfo BufferVK::writeAllocationInfo(const BufferInfo& bufferIn
 
 bool BufferVK::mapCopyUnmap(const void* pData, VkDeviceSize size)
 {
+    VmaAllocationInfo allocationInfo = getAllocationInfo();
     VkDevice device = m_pDevice->getDevice();
-    VmaAllocationInfo allocationInfo = {};
-    vmaGetAllocationInfo(m_pDevice->getVulkanAllocator(), m_Allocation, &allocationInfo);
-
     void* pMappedData = nullptr;
+
     if (vkMapMemory(device, allocationInfo.deviceMemory, 0u, size, 0, &pMappedData) != VK_SUCCESS) {
         LOG_WARNING("Failed to map buffer memory");
         return false;

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/BufferVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/BufferVK.hpp
@@ -18,6 +18,7 @@ public:
     ~BufferVK();
 
     inline VkBuffer getBuffer() { return m_Buffer; }
+    VmaAllocationInfo getAllocationInfo() const;
 
 private:
     static VkBufferCreateInfo convertBufferInfo(const BufferInfo& bufferInfo);

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp
@@ -20,9 +20,6 @@ public:
     // Shader resources
     void bindDescriptorSet(DescriptorSet* pDescriptorSet) override final {};
 
-    void map(IBuffer* pBuffer, void** ppMappedMemory) override final {};
-    void unmap(IBuffer* pBuffer) override final {};
-
     void bindVertexBuffer(uint32_t firstBinding, IBuffer* pBuffer) override final {};
     void bindIndexBuffer(IBuffer* pBuffer) override final {};
 

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.cpp
@@ -1,5 +1,6 @@
 #include "DeviceVK.hpp"
 
+#include <Engine/Rendering/APIAbstractions/Vulkan/BufferVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/CommandPoolVK.hpp>
 #include <Engine/Rendering/Window.hpp>
@@ -73,6 +74,24 @@ bool DeviceVK::computeQueueSubmit(ICommandList* pCommandList)
     }
 
     return true;
+}
+
+void DeviceVK::map(IBuffer* pBuffer, void** ppMappedMemory)
+{
+    BufferVK* pBufferVK = reinterpret_cast<BufferVK*>(pBuffer);
+    VmaAllocationInfo allocationInfo = pBufferVK->getAllocationInfo();
+
+    if (vkMapMemory(m_Device, allocationInfo.deviceMemory, 0u, VK_WHOLE_SIZE, 0, ppMappedMemory) != VK_SUCCESS) {
+        LOG_WARNING("Failed to map buffer memory");
+    }
+}
+
+void DeviceVK::unmap(IBuffer* pBuffer)
+{
+    BufferVK* pBufferVK = reinterpret_cast<BufferVK*>(pBuffer);
+    VmaAllocationInfo allocationInfo = pBufferVK->getAllocationInfo();
+
+    vkUnmapMemory(m_Device, allocationInfo.deviceMemory);
 }
 
 VKAPI_ATTR VkBool32 VKAPI_CALL DeviceVK::vulkanCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData)

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
@@ -2,10 +2,10 @@
 
 #include <vulkan/vulkan.h>
 
-class DeviceCreatorVK;
-
 #define NOMINMAX
 #include <vma/vk_mem_alloc.h>
+
+class DeviceCreatorVK;
 
 struct Queues {
     VkQueue Graphics;
@@ -53,24 +53,28 @@ public:
     IPipelineLayout* createPipelineLayout(std::vector<IDescriptorSetLayout*> descriptorSetLayout) override final { return nullptr; }
     IPipeline* createPipeline(const PipelineInfo& pipelineInfo) override final { return nullptr; }
 
-    IBuffer* createBuffer(const BufferInfo& bufferInfo, StagingResources* pStagingResources = nullptr) override final                                          { return nullptr; }
-    IBuffer* createVertexBuffer(const void* pVertices, size_t vertexSize, size_t vertexCount) override final    { return nullptr; }
-    IBuffer* createIndexBuffer(const unsigned* pIndices, size_t indexCount) override final                      { return nullptr; }
+    void map(IBuffer* pBuffer, void** ppMappedMemory) override final;
+    void unmap(IBuffer* pBuffer) override final;
+
+    // Shader resources
+    IBuffer* createBuffer(const BufferInfo& bufferInfo, StagingResources* pStagingResources = nullptr) override final   { return nullptr; }
+    IBuffer* createVertexBuffer(const void* pVertices, size_t vertexSize, size_t vertexCount) override final            { return nullptr; }
+    IBuffer* createIndexBuffer(const unsigned* pIndices, size_t indexCount) override final                              { return nullptr; }
 
     Texture* createTextureFromFile(const std::string& filePath) override final  { return nullptr; }
     Texture* createTexture(const TextureInfo& textureInfo) override final       { return nullptr; }
 
     ISampler* createSampler(const SamplerInfo& samplerInfo) override final      { return nullptr; }
 
-    std::string getShaderPostfixAndExtension(SHADER_TYPE shaderType)            { return ""; }
+    std::string getShaderPostfixAndExtension(SHADER_TYPE shaderType) override final { return ""; }
 
     IRasterizerState* createRasterizerState(const RasterizerStateInfo& rasterizerInfo) override final       { return nullptr; }
 
     BlendState* createBlendState(const BlendStateInfo& blendStateInfo) override final                       { return nullptr; }
     IDepthStencilState* createDepthStencilState(const DepthStencilInfo& depthStencilInfo) override final    { return nullptr; }
 
-    VmaAllocator getVulkanAllocator() { return m_Allocator; }
-    VkDevice getDevice() { return m_Device; }
+    VmaAllocator getVulkanAllocator()   { return m_Allocator; }
+    VkDevice getDevice()                { return m_Device; }
 
 protected:
     DescriptorPool* createDescriptorPool(const DescriptorCounts& poolSize) override final { return nullptr; }

--- a/GameProject/Engine/Rendering/MeshRenderer.cpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.cpp
@@ -136,9 +136,9 @@ void MeshRenderer::updateBuffers()
     perFrame.NumLights = numLights;
 
     void* pMappedMemory = nullptr;
-    m_pCommandList->map(m_pPointLightBuffer, &pMappedMemory);
+    m_pDevice->map(m_pPointLightBuffer, &pMappedMemory);
     memcpy(pMappedMemory, &perFrame, sizeof(PerFrameBuffer));
-    m_pCommandList->unmap(m_pPointLightBuffer);
+    m_pDevice->unmap(m_pPointLightBuffer);
 
     for (Entity renderableID : m_Renderables.getIDs()) {
         ModelRenderResources& modelRenderResources = m_ModelRenderResources.indexID(renderableID);
@@ -154,9 +154,9 @@ void MeshRenderer::updateBuffers()
         DirectX::XMStoreFloat4x4(&matrices.WVP, DirectX::XMMatrixTranspose(DirectX::XMLoadFloat4x4(&matrices.World) * camVP));
 
         pMappedMemory = nullptr;
-        m_pCommandList->map(modelRenderResources.pWVPBuffer, &pMappedMemory);
+        m_pDevice->map(modelRenderResources.pWVPBuffer, &pMappedMemory);
         memcpy(pMappedMemory, &matrices, sizeof(PerObjectMatrices));
-        m_pCommandList->unmap(modelRenderResources.pWVPBuffer);
+        m_pDevice->unmap(modelRenderResources.pWVPBuffer);
     }
 }
 

--- a/GameProject/Engine/UI/UIRenderer.cpp
+++ b/GameProject/Engine/UI/UIRenderer.cpp
@@ -101,9 +101,9 @@ void UIRenderer::updateBuffers()
 
         // Set per-object buffer
         void* pMappedBuffer = nullptr;
-        m_pCommandList->map(panelRenderResources.pBuffer, &pMappedBuffer);
+        m_pDevice->map(panelRenderResources.pBuffer, &pMappedBuffer);
         memcpy(pMappedBuffer, &panel, bufferSize);
-        m_pCommandList->unmap(panelRenderResources.pBuffer);
+        m_pDevice->unmap(panelRenderResources.pBuffer);
     }
 }
 


### PR DESCRIPTION
Move `map` and `unmap` functions to `Device`, they were originally in `ICommandList`.