### PR TITLE
Vulkan descriptors

### DIFF
--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorPoolDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorPoolDX11.cpp
@@ -3,21 +3,12 @@
 #include <Engine/Rendering/APIAbstractions/DX11/DescriptorSetLayoutDX11.hpp>
 #include <Engine/Utils/Debug.hpp>
 
-void DescriptorPoolDX11::init(const DescriptorCounts& descriptorCounts)
-{
-    m_AvailableDescriptors = descriptorCounts;
-}
+DescriptorPoolDX11::DescriptorPoolDX11(const DescriptorPoolInfo& poolInfo)
+    :DescriptorPool(poolInfo)
+{}
 
 DescriptorSetDX11* DescriptorPoolDX11::allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout)
 {
-    m_AvailableDescriptors -= pDescriptorSetLayout->getDescriptorCounts();
-
     const DescriptorSetLayoutDX11* pDescriptorSetLayoutDX = reinterpret_cast<const DescriptorSetLayoutDX11*>(pDescriptorSetLayout);
     return DBG_NEW DescriptorSetDX11(pDescriptorSetLayoutDX, this);
-}
-
-void DescriptorPoolDX11::deallocateDescriptorSet(const DescriptorSet* pDescriptorSet)
-{
-    m_AvailableDescriptors += pDescriptorSet->getLayout()->getDescriptorCounts();
-    return;
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorPoolDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorPoolDX11.hpp
@@ -8,10 +8,9 @@
 class DescriptorPoolDX11 : public DescriptorPool
 {
 public:
-    DescriptorPoolDX11() = default;
+    DescriptorPoolDX11(const DescriptorPoolInfo& poolInfo);
     ~DescriptorPoolDX11() = default;
 
-    void init(const DescriptorCounts& descriptorCounts) override final;
     DescriptorSetDX11* allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout) override final;
-    void deallocateDescriptorSet(const DescriptorSet* pDescriptorSet) override final;
+    void deallocateDescriptorSet(const DescriptorSet* pDescriptorSet) override final { return; };
 };

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetDX11.cpp
@@ -11,7 +11,7 @@ DescriptorSetDX11::DescriptorSetDX11(const DescriptorSetLayoutDX11* pDescriptorS
     m_pLayout(pDescriptorSetLayout)
 {}
 
-void DescriptorSetDX11::writeUniformBufferDescriptor(SHADER_BINDING binding, IBuffer* pBuffer)
+void DescriptorSetDX11::updateUniformBufferDescriptor(SHADER_BINDING binding, IBuffer* pBuffer)
 {
     BufferDX11* pBufferDX = reinterpret_cast<BufferDX11*>(pBuffer);
     Binding<ID3D11Buffer> bufferBinding = {
@@ -23,7 +23,7 @@ void DescriptorSetDX11::writeUniformBufferDescriptor(SHADER_BINDING binding, IBu
     m_BufferBindings.push_back(bufferBinding);
 }
 
-void DescriptorSetDX11::writeSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture)
+void DescriptorSetDX11::updateSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture)
 {
     TextureDX11* pTextureDX = reinterpret_cast<TextureDX11*>(pTexture);
     Binding<ID3D11ShaderResourceView> textureBinding = {
@@ -35,7 +35,7 @@ void DescriptorSetDX11::writeSampledTextureDescriptor(SHADER_BINDING binding, Te
     m_SampledTextureBindings.push_back(textureBinding);
 }
 
-void DescriptorSetDX11::writeSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler)
+void DescriptorSetDX11::updateSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler)
 {
     SamplerDX11* pSamplerDX = reinterpret_cast<SamplerDX11*>(pSampler);
     Binding<ID3D11SamplerState> samplerBinding = {

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetDX11.hpp
@@ -24,9 +24,9 @@ public:
     DescriptorSetDX11(const DescriptorSetLayoutDX11* pDescriptorSetLayout, DescriptorPool* pDescriptorPool);
     ~DescriptorSetDX11() = default;
 
-    void writeUniformBufferDescriptor(SHADER_BINDING binding, IBuffer* pBuffer) override final;
-    void writeSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture) override final;
-    void writeSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler) override final;
+    void updateUniformBufferDescriptor(SHADER_BINDING binding, IBuffer* pBuffer) override final;
+    void updateSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture) override final;
+    void updateSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler) override final;
 
     void bind(ID3D11DeviceContext* pContext);
 

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetLayoutDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetLayoutDX11.cpp
@@ -21,7 +21,7 @@ void DescriptorSetLayoutDX11::addBindingSampler(SHADER_BINDING binding, SHADER_T
     m_SamplerSlots.push_back({bindingU, shaderStages});
 }
 
-bool DescriptorSetLayoutDX11::finalize()
+bool DescriptorSetLayoutDX11::finalize(Device* pDevice)
 {
     m_UniformBufferSlots.shrink_to_fit();
     m_SampledTextureSlots.shrink_to_fit();

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetLayoutDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetLayoutDX11.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Engine/Rendering/APIAbstractions/DescriptorPool.hpp>
 #include <Engine/Rendering/APIAbstractions/DescriptorSetLayout.hpp>
 
 #include <unordered_map>
@@ -21,7 +20,7 @@ public:
     void addBindingSampledTexture(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
     void addBindingSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
 
-    bool finalize() override final;
+    bool finalize(Device* pDevice) override final;
 
     DescriptorCounts getDescriptorCounts() const override final;
 

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
@@ -131,11 +131,9 @@ BlendStateDX11* DeviceDX11::createBlendState(const BlendStateInfo& blendStateInf
     return BlendStateDX11::create(blendStateInfo, m_pDevice);
 }
 
-DescriptorPoolDX11* DeviceDX11::createDescriptorPool(const DescriptorCounts& poolSize)
+DescriptorPoolDX11* DeviceDX11::createDescriptorPool(const DescriptorPoolInfo& poolInfo)
 {
-    DescriptorPoolDX11* pNewDescriptorPool = DBG_NEW DescriptorPoolDX11();
-    pNewDescriptorPool->init(poolSize);
-    return pNewDescriptorPool;
+    return DBG_NEW DescriptorPoolDX11(poolInfo);
 }
 
 ShaderDX11* DeviceDX11::compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo, InputLayout** ppInputLayout)

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
@@ -78,7 +78,7 @@ public:
     ID3D11DeviceContext* getContext()   { return m_pContext; }
 
 protected:
-    DescriptorPoolDX11* createDescriptorPool(const DescriptorCounts& poolSize) override final;
+    DescriptorPoolDX11* createDescriptorPool(const DescriptorPoolInfo& poolInfo) override final;
 
 private:
     ShaderDX11* compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo, InputLayout** ppInputLayout) override final;

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorCounts.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorCounts.cpp
@@ -18,9 +18,10 @@ DescriptorCounts& DescriptorCounts::operator+=(const DescriptorCounts& other)
 
 DescriptorCounts& DescriptorCounts::operator-=(const DescriptorCounts& other)
 {
-    m_UniformBuffers    -= other.m_UniformBuffers;
-    m_SampledTextures   -= other.m_SampledTextures;
-    m_Samplers          -= other.m_Samplers;
+    // Avoid underflow
+    m_UniformBuffers    = (uint32_t)std::max(0, (int)m_UniformBuffers - (int)other.m_UniformBuffers);
+    m_SampledTextures   = (uint32_t)std::max(0, (int)m_SampledTextures - (int)other.m_SampledTextures);
+    m_Samplers          = (uint32_t)std::max(0, (int)m_Samplers - (int)other.m_Samplers);
     return *this;
 }
 
@@ -60,4 +61,12 @@ std::string DescriptorCounts::toString() const
         "Uniform Buffers: "     + std::to_string(m_UniformBuffers) + ", " +
         "Sampled Textures: "    + std::to_string(m_SampledTextures) + ", " +
         "Samplers: "            + std::to_string(m_Samplers);
+}
+
+uint32_t DescriptorCounts::getDescriptorTypeCount() const
+{
+    return
+        m_UniformBuffers    != 0u +
+        m_SampledTextures   != 0u +
+        m_Samplers          != 0u;
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorCounts.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorCounts.hpp
@@ -23,6 +23,9 @@ public:
 
     std::string toString() const;
 
+    // Gets the amount of unique descriptor types, i.e. the amount of descriptor types whose counts aren't 0
+    uint32_t getDescriptorTypeCount() const;
+
     uint32_t m_UniformBuffers;
     uint32_t m_SampledTextures;
     uint32_t m_Samplers;

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorPool.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorPool.cpp
@@ -1,5 +1,22 @@
 #include "DescriptorPool.hpp"
 
+DescriptorPool::DescriptorPool(const DescriptorPoolInfo& descriptorPoolInfo)
+    :m_AvailableDescriptors(descriptorPoolInfo.DescriptorCounts),
+    m_DescriptorSetCapacity(descriptorPoolInfo.MaxSetAllocations)
+{}
+
+void DescriptorPool::allocatedDescriptorSet(const DescriptorCounts& descriptorCounts)
+{
+    m_AvailableDescriptors -= descriptorCounts;
+    m_DescriptorSetCapacity += 1u;
+}
+
+void DescriptorPool::deallocatedDescriptorSet(const DescriptorCounts& descriptorCounts)
+{
+    m_AvailableDescriptors += descriptorCounts;
+    m_DescriptorSetCapacity -= 1u;
+}
+
 bool DescriptorPool::hasRoomFor(const DescriptorCounts& descriptorCounts)
 {
     return m_AvailableDescriptors.contains(descriptorCounts);

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorPool.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorPool.hpp
@@ -5,18 +5,31 @@
 class DescriptorSet;
 class IDescriptorSetLayout;
 
+struct DescriptorPoolInfo {
+    bool FreeableDescriptorSets;
+    DescriptorCounts DescriptorCounts;
+    uint32_t MaxSetAllocations;
+};
+
 class DescriptorPool
 {
 public:
+    DescriptorPool(const DescriptorPoolInfo& descriptorPoolInfo);
     virtual ~DescriptorPool() = 0 {};
-
-    virtual void init(const DescriptorCounts& descriptorCounts) = 0;
 
     virtual DescriptorSet* allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout) = 0;
     virtual void deallocateDescriptorSet(const DescriptorSet* pDescriptorSet) = 0;
+
+    // Increase or decrease the capacity after allocating or deallocating a descripotr set
+    void allocatedDescriptorSet(const DescriptorCounts& descriptorCounts);
+    void deallocatedDescriptorSet(const DescriptorCounts& descriptorCounts);
 
     bool hasRoomFor(const DescriptorCounts& descriptorCounts);
 
 protected:
     DescriptorCounts m_AvailableDescriptors;
+
+private:
+    // The amount of additional descriptor sets the pool is able to allocate
+    uint32_t m_DescriptorSetCapacity;
 };

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorPoolHandler.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorPoolHandler.hpp
@@ -13,13 +13,13 @@ public:
     DescriptorPoolHandler() = default;
     ~DescriptorPoolHandler();
 
-    // Specify the size of the pools that will be created. Optimally, only one pool will be created, but more can be created if needed.
-    void init(const DescriptorCounts& poolSizes, Device* pDevice);
+    // Specify the settingsfor pools that will be created. Optimally, only one pool will be created, but more can be created if needed.
+    void init(const DescriptorPoolInfo& poolInfos, Device* pDevice);
 
     DescriptorSet* allocateDescriptorSet(const IDescriptorSetLayout* pLayout, Device* pDevice);
 
 private:
     std::vector<DescriptorPool*> m_DescriptorPools;
 
-    DescriptorCounts m_PoolSizes;
+    DescriptorPoolInfo m_PoolInfos;
 };

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorSet.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorSet.cpp
@@ -1,6 +1,7 @@
 #include "DescriptorSet.hpp"
 
 #include <Engine/Rendering/APIAbstractions/DescriptorPool.hpp>
+#include <Engine/Rendering/APIAbstractions/DX11/DescriptorSetLayoutDX11.hpp>
 
 DescriptorSet::DescriptorSet(DescriptorPool* pDescriptorPool, const IDescriptorSetLayout* pLayout)
     :m_pDescriptorPool(pDescriptorPool),
@@ -10,4 +11,5 @@ DescriptorSet::DescriptorSet(DescriptorPool* pDescriptorPool, const IDescriptorS
 DescriptorSet::~DescriptorSet()
 {
     m_pDescriptorPool->deallocateDescriptorSet(this);
+    m_pDescriptorPool->deallocatedDescriptorSet(reinterpret_cast<const DescriptorSetLayoutDX11*>(m_pLayout)->getDescriptorCounts());
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorSet.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorSet.hpp
@@ -14,13 +14,13 @@ public:
     DescriptorSet(DescriptorPool* pDescriptorPool, const IDescriptorSetLayout* pLayout);
     virtual ~DescriptorSet();
 
-    virtual void writeUniformBufferDescriptor(SHADER_BINDING binding, IBuffer* pBuffer) = 0;
-    virtual void writeSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture) = 0;
-    virtual void writeSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler) = 0;
+    virtual void updateUniformBufferDescriptor(SHADER_BINDING binding, IBuffer* pBuffer) = 0;
+    virtual void updateSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture) = 0;
+    virtual void updateSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler) = 0;
 
     const IDescriptorSetLayout* getLayout() const { return m_pLayout; }
 
-private:
+protected:
     DescriptorPool* m_pDescriptorPool;
     const IDescriptorSetLayout* m_pLayout;
 };

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorSetLayout.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorSetLayout.hpp
@@ -4,16 +4,18 @@
 #include <Engine/Rendering/APIAbstractions/Shader.hpp>
 #include <Engine/Rendering/ShaderBindings.hpp>
 
+class Device;
+
 class IDescriptorSetLayout
 {
 public:
     virtual ~IDescriptorSetLayout() = 0 {};
 
+    virtual bool finalize(Device* pDevice) = 0;
+
     virtual void addBindingUniformBuffer(SHADER_BINDING binding, SHADER_TYPE shaderStages) = 0;
     virtual void addBindingSampledTexture(SHADER_BINDING binding, SHADER_TYPE shaderStages) = 0;
     virtual void addBindingSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages) = 0;
-
-    virtual bool finalize() = 0;
 
     // How many descriptors of each type are involved in the layout
     virtual DescriptorCounts getDescriptorCounts() const = 0;

--- a/GameProject/Engine/Rendering/APIAbstractions/Device.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Device.cpp
@@ -54,7 +54,11 @@ bool Device::init(const DescriptorCounts& descriptorCounts)
         return false;
     }
 
-    m_DescriptorPoolHandler.init(descriptorCounts, this);
+    DescriptorPoolInfo descriptorPoolInfo = {};
+    descriptorPoolInfo.DescriptorCounts         = descriptorCounts;
+    descriptorPoolInfo.MaxSetAllocations        = 25u;
+    descriptorPoolInfo.FreeableDescriptorSets   = true;
+    m_DescriptorPoolHandler.init(descriptorPoolInfo, this);
 
     m_pShaderHandler = DBG_NEW ShaderHandler(this);
     return m_pShaderHandler;

--- a/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
@@ -133,7 +133,7 @@ public:
 protected:
     friend DescriptorPoolHandler;
 
-    virtual DescriptorPool* createDescriptorPool(const DescriptorCounts& poolSize) = 0;
+    virtual DescriptorPool* createDescriptorPool(const DescriptorPoolInfo& poolInfo) = 0;
 
 protected:
     DescriptorPoolHandler m_DescriptorPoolHandler;

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.cpp
@@ -1,0 +1,65 @@
+#include "DescriptorPoolVK.hpp"
+
+#include <Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.hpp>
+#include <Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetVK.hpp>
+#include <Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp>
+
+DescriptorPoolVK* DescriptorPoolVK::create(const DescriptorPoolInfo& poolInfo, DeviceVK* pDevice)
+{
+    VkDescriptorPoolCreateInfo poolCreateInfo = {};
+    poolCreateInfo.sType            = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    poolCreateInfo.flags            = poolInfo.FreeableDescriptorSets ? VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT : 0u;
+    poolCreateInfo.maxSets          = poolInfo.MaxSetAllocations;
+    poolCreateInfo.poolSizeCount    = poolInfo.DescriptorCounts.getDescriptorTypeCount();
+
+    std::vector<VkDescriptorPoolSize> descriptorCounts(poolCreateInfo.poolSizeCount);
+    descriptorCounts[0].type            = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    descriptorCounts[0].descriptorCount = poolInfo.DescriptorCounts.m_UniformBuffers;
+
+    descriptorCounts[1].type            = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    descriptorCounts[1].descriptorCount = poolInfo.DescriptorCounts.m_SampledTextures;
+
+    descriptorCounts[2].type            = VK_DESCRIPTOR_TYPE_SAMPLER;
+    descriptorCounts[2].descriptorCount = poolInfo.DescriptorCounts.m_Samplers;
+
+    poolCreateInfo.pPoolSizes = descriptorCounts.data();
+
+    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    if (vkCreateDescriptorPool(pDevice->getDevice(), &poolCreateInfo, nullptr, &descriptorPool) != VK_SUCCESS) {
+        LOG_ERROR("Failed to create descriptor pool");
+        return nullptr;
+    }
+
+    return DBG_NEW DescriptorPoolVK(descriptorPool, poolInfo, pDevice);
+}
+
+DescriptorPoolVK::DescriptorPoolVK(VkDescriptorPool descriptorPool, const DescriptorPoolInfo& poolInfo, DeviceVK* pDevice)
+    :DescriptorPool(poolInfo),
+    m_DescriptorPool(descriptorPool),
+    m_pDevice(pDevice)
+{}
+
+DescriptorPoolVK::~DescriptorPoolVK()
+{
+    vkDestroyDescriptorPool(m_pDevice->getDevice(), m_DescriptorPool, nullptr);
+}
+
+DescriptorSetVK* DescriptorPoolVK::allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout)
+{
+    VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
+    if (vkAllocateDescriptorSets(m_pDevice->getDevice(), nullptr, &descriptorSet) != VK_SUCCESS) {
+        LOG_ERROR("Failed to allocate descriptor set");
+        return nullptr;
+    }
+
+    const DescriptorSetLayoutVK* pLayoutVK = reinterpret_cast<const DescriptorSetLayoutVK*>(pDescriptorSetLayout);
+    return DBG_NEW DescriptorSetVK(descriptorSet, this, pLayoutVK, m_pDevice);
+}
+
+void DescriptorPoolVK::deallocateDescriptorSet(const DescriptorSet* pDescriptorSet)
+{
+    VkDescriptorSet descriptorSet = reinterpret_cast<const DescriptorSetVK*>(pDescriptorSet)->getDescriptorSet();
+    if (vkFreeDescriptorSets(m_pDevice->getDevice(), m_DescriptorPool, 1u, &descriptorSet) != VK_SUCCESS) {
+        LOG_ERROR("Failed to free descriptor set");
+    }
+}

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <Engine/Rendering/APIAbstractions/DescriptorPool.hpp>
+#include <Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetVK.hpp>
+
+#include <vulkan/vulkan.h>
+
+class DeviceVK;
+
+class DescriptorPoolVK : public DescriptorPool
+{
+public:
+    static DescriptorPoolVK* create(const DescriptorPoolInfo& poolInfo, DeviceVK* pDevice);
+
+public:
+    DescriptorPoolVK(VkDescriptorPool descriptorPool, const DescriptorPoolInfo& poolInfo, DeviceVK* pDevice);
+    ~DescriptorPoolVK();
+
+    DescriptorSetVK* allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout) override final;
+    void deallocateDescriptorSet(const DescriptorSet* pDescriptorSet) override final;
+
+    inline VkDescriptorPool getDescriptorPool() { return m_DescriptorPool; }
+
+private:
+    VkDescriptorPool m_DescriptorPool;
+    DeviceVK* m_pDevice;
+};

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.cpp
@@ -1,0 +1,54 @@
+#include "DescriptorSetLayoutVK.hpp"
+
+#include <Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp>
+#include <Engine/Rendering/APIAbstractions/Vulkan/ShaderVK.hpp>
+
+bool DescriptorSetLayoutVK::finalize(Device* pDevice)
+{
+    m_pDevice = reinterpret_cast<DeviceVK*>(pDevice);
+
+    VkDescriptorSetLayoutCreateInfo layoutInfo = {};
+    layoutInfo.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
+    layoutInfo.bindingCount = (uint32_t)m_Bindings.size();
+    layoutInfo.pBindings    = m_Bindings.data();
+
+    VkDevice device = reinterpret_cast<DeviceVK*>(pDevice)->getDevice();
+    VkDescriptorSetLayout layout = VK_NULL_HANDLE;
+    if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &layout) != VK_SUCCESS) {
+        LOG_ERROR("Failed to create descriptor set layout");
+        return false;
+    }
+
+    return true;
+}
+
+DescriptorSetLayoutVK::~DescriptorSetLayoutVK()
+{
+    vkDestroyDescriptorSetLayout(m_pDevice->getDevice(), m_DescriptorSetLayout, nullptr);
+}
+
+void DescriptorSetLayoutVK::addBindingUniformBuffer(SHADER_BINDING binding, SHADER_TYPE shaderStages)
+{
+    addBinding((uint32_t)binding, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, shaderStages);
+}
+
+void DescriptorSetLayoutVK::addBindingSampledTexture(SHADER_BINDING binding, SHADER_TYPE shaderStages)
+{
+    addBinding((uint32_t)binding, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, shaderStages);
+}
+
+void DescriptorSetLayoutVK::addBindingSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages)
+{
+    addBinding((uint32_t)binding, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, shaderStages);
+}
+
+void DescriptorSetLayoutVK::addBinding(uint32_t binding, VkDescriptorType descriptorType, SHADER_TYPE shaderStages)
+{
+    VkDescriptorSetLayoutBinding bindingInfo = {};
+    bindingInfo.binding         = binding;
+    bindingInfo.descriptorType  = descriptorType;
+    bindingInfo.descriptorCount = 1u;
+    bindingInfo.stageFlags      = ShaderVK::convertShaderFlags(shaderStages);
+
+    m_Bindings.push_back(bindingInfo);
+}

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Engine/Rendering/APIAbstractions/DescriptorSetLayout.hpp>
+
+#include <vulkan/vulkan.h>
+
+class DeviceVK;
+
+struct BindingSlot {
+    uint32_t Binding;
+    SHADER_TYPE ShaderStages;
+};
+
+class DescriptorSetLayoutVK : public IDescriptorSetLayout
+{
+public:
+    DescriptorSetLayoutVK() = default;
+    ~DescriptorSetLayoutVK();
+
+    bool finalize(Device* pDevice) override final;
+
+    void addBindingUniformBuffer(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
+    void addBindingSampledTexture(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
+    void addBindingSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
+
+private:
+    void addBinding(uint32_t binding, VkDescriptorType descriptorType, SHADER_TYPE shaderStages);
+
+private:
+    VkDescriptorSetLayout m_DescriptorSetLayout;
+    std::vector<VkDescriptorSetLayoutBinding> m_Bindings;
+
+    DeviceVK* m_pDevice;
+};

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetVK.cpp
@@ -1,0 +1,55 @@
+#include "DescriptorSetVK.hpp"
+
+#include <Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.hpp>
+#include <Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.hpp>
+#include <Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp>
+//#include <Engine/Rendering/APIAbstractions/Vulkan/SamplerVK.hpp>
+#include <Engine/Rendering/APIAbstractions/Vulkan/TextureVK.hpp>
+
+DescriptorSetVK::DescriptorSetVK(VkDescriptorSet descriptorSet, DescriptorPoolVK* pDescriptorPool, const DescriptorSetLayoutVK* pLayout, DeviceVK* pDevice)
+    :DescriptorSet(pDescriptorPool, pLayout),
+    m_DescriptorSet(descriptorSet),
+    m_pDevice(pDevice)
+{}
+
+void DescriptorSetVK::updateUniformBufferDescriptor(SHADER_BINDING binding, IBuffer* pBuffer)
+{
+    VkDescriptorBufferInfo bufferInfo = {};
+    bufferInfo.buffer = reinterpret_cast<BufferVK*>(pBuffer)->getBuffer();
+    bufferInfo.range  = VK_WHOLE_SIZE;
+
+    updateDescriptor(binding, nullptr, &bufferInfo);
+}
+
+void DescriptorSetVK::updateSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture)
+{
+    VkDescriptorImageInfo imageInfo = {};
+    imageInfo.imageView     = reinterpret_cast<TextureVK*>(pTexture)->getImageView();
+    imageInfo.imageLayout   = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    updateDescriptor(binding, &imageInfo, nullptr);
+}
+
+void DescriptorSetVK::updateSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler)
+{
+    VkDescriptorImageInfo imageInfo = {};
+    // TODO: Implement SamplerVK
+    //imageInfo.sampler       = reinterpret_cast<SamplerVK*>(pSampler)->getSampler();
+
+    updateDescriptor(binding, &imageInfo, nullptr);
+}
+
+void DescriptorSetVK::updateDescriptor(SHADER_BINDING binding, const VkDescriptorImageInfo* pImageInfo, const VkDescriptorBufferInfo* pBufferInfo)
+{
+    VkWriteDescriptorSet writeInfo = {};
+    writeInfo.sType             = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writeInfo.dstSet            = m_DescriptorSet;
+    writeInfo.dstBinding        = (uint32_t)binding;
+    writeInfo.dstArrayElement   = 0u;
+    writeInfo.descriptorCount   = 1u;
+    writeInfo.descriptorType    = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    writeInfo.pImageInfo        = pImageInfo;
+    writeInfo.pBufferInfo       = pBufferInfo;
+
+    vkUpdateDescriptorSets(m_pDevice->getDevice(), 1u, &writeInfo, 0u, nullptr);
+}

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetVK.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Engine/Rendering/APIAbstractions/DescriptorSet.hpp>
+
+#include <vulkan/vulkan.h>
+
+class DescriptorPoolVK;
+class DescriptorSetLayoutVK;
+class DeviceVK;
+
+class DescriptorSetVK : public DescriptorSet
+{
+public:
+    DescriptorSetVK(VkDescriptorSet descriptorSet, DescriptorPoolVK* pDescriptorPool, const DescriptorSetLayoutVK* pLayout, DeviceVK* pDevice);
+    ~DescriptorSetVK() = default;
+
+    void updateUniformBufferDescriptor(SHADER_BINDING binding, IBuffer* pBuffer) override final;
+    void updateSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture) override final;
+    void updateSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler) override final;
+
+    inline VkDescriptorSet getDescriptorSet() const { return m_DescriptorSet; }
+
+private:
+    void updateDescriptor(SHADER_BINDING binding, const VkDescriptorImageInfo* pImageInfo, const VkDescriptorBufferInfo* pBufferInfo);
+
+private:
+    VkDescriptorSet m_DescriptorSet;
+
+    DeviceVK* m_pDevice;
+};

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.cpp
@@ -3,6 +3,7 @@
 #include <Engine/Rendering/APIAbstractions/Vulkan/BufferVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/CommandPoolVK.hpp>
+#include <Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/GeneralResourcesVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/SemaphoreVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/ShaderVK.hpp>
@@ -120,6 +121,11 @@ bool DeviceVK::waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAl
     }
 
     return vkWaitForFences(m_Device, fenceCount, fences.data(), (VkBool32)waitAll, timeout) == VK_SUCCESS;
+}
+
+DescriptorPool* DeviceVK::createDescriptorPool(const DescriptorPoolInfo& poolInfo)
+{
+    return DescriptorPoolVK::create(poolInfo, this);
 }
 
 VKAPI_ATTR VkBool32 VKAPI_CALL DeviceVK::vulkanCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData)

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
@@ -84,7 +84,7 @@ public:
     VkDevice getDevice()                { return m_Device; }
 
 protected:
-    DescriptorPool* createDescriptorPool(const DescriptorCounts& poolSize) override final { return nullptr; }
+    DescriptorPool* createDescriptorPool(const DescriptorPoolInfo& poolInfo) override final;
 
 private:
     friend DeviceCreatorVK;

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/ShaderVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/ShaderVK.cpp
@@ -34,6 +34,16 @@ ShaderVK* ShaderVK::compileShader(const std::string& filePath, SHADER_TYPE shade
     return DBG_NEW ShaderVK(shaderModule, shaderType, pDevice);
 }
 
+VkShaderStageFlags ShaderVK::convertShaderFlags(SHADER_TYPE shaderFlags)
+{
+    return
+        HAS_FLAG(shaderFlags, SHADER_TYPE::VERTEX_SHADER)   * VK_SHADER_STAGE_VERTEX_BIT |
+        HAS_FLAG(shaderFlags, SHADER_TYPE::HULL_SHADER)     * VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT |
+        HAS_FLAG(shaderFlags, SHADER_TYPE::DOMAIN_SHADER)   * VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT |
+        HAS_FLAG(shaderFlags, SHADER_TYPE::GEOMETRY_SHADER) * VK_SHADER_STAGE_GEOMETRY_BIT |
+        HAS_FLAG(shaderFlags, SHADER_TYPE::FRAGMENT_SHADER) * VK_SHADER_STAGE_FRAGMENT_BIT;
+}
+
 ShaderVK::ShaderVK(VkShaderModule shaderModule, SHADER_TYPE shaderType, DeviceVK* pDevice)
     :Shader(shaderType),
     m_ShaderModule(shaderModule),

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/ShaderVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/ShaderVK.hpp
@@ -13,6 +13,8 @@ class ShaderVK : public Shader
 public:
     static ShaderVK* compileShader(const std::string& filePath, SHADER_TYPE shaderType, DeviceVK* pDevice);
 
+    static VkShaderStageFlags convertShaderFlags(SHADER_TYPE shaderFlags);
+
 public:
     ShaderVK(VkShaderModule shaderModule, SHADER_TYPE shaderType, DeviceVK* pDevice);
     ~ShaderVK();

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.hpp
@@ -27,7 +27,8 @@ public:
 
     bool convertTextureLayout(VkCommandBuffer commandBuffer, TEXTURE_LAYOUT oldLayout, TEXTURE_LAYOUT newLayout, PIPELINE_STAGE srcStage, PIPELINE_STAGE dstStage);
 
-    inline VkImage getImage() { return m_Image; }
+    inline VkImage getImage()           { return m_Image; }
+    inline VkImageView getImageView()   { return m_ImageView; }
 
 private:
     static bool setInitialData(TextureVK* pTexture, const TextureInfoVK& textureInfo, DeviceVK* pDevice);

--- a/GameProject/Engine/Rendering/MeshRenderer.cpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.cpp
@@ -246,7 +246,7 @@ bool MeshRenderer::createDescriptorSetLayouts()
     m_pDescriptorSetLayoutCommon->addBindingUniformBuffer(SHADER_BINDING::PER_FRAME, SHADER_TYPE::FRAGMENT_SHADER);
     m_pDescriptorSetLayoutCommon->addBindingSampler(SHADER_BINDING::SAMPLER_ONE, SHADER_TYPE::FRAGMENT_SHADER);
 
-    if (!m_pDescriptorSetLayoutCommon->finalize()) {
+    if (!m_pDescriptorSetLayoutCommon->finalize(m_pDevice)) {
         return false;
     }
 
@@ -255,7 +255,7 @@ bool MeshRenderer::createDescriptorSetLayouts()
 
     m_pDescriptorSetLayoutModel->addBindingUniformBuffer(SHADER_BINDING::PER_OBJECT, SHADER_TYPE::VERTEX_SHADER);
 
-    if (!m_pDescriptorSetLayoutModel->finalize()) {
+    if (!m_pDescriptorSetLayoutModel->finalize(m_pDevice)) {
         return false;
     }
 
@@ -265,7 +265,7 @@ bool MeshRenderer::createDescriptorSetLayouts()
     m_pDescriptorSetLayoutMesh->addBindingUniformBuffer(SHADER_BINDING::MATERIAL_CONSTANTS, SHADER_TYPE::FRAGMENT_SHADER);
     m_pDescriptorSetLayoutMesh->addBindingSampledTexture(SHADER_BINDING::TEXTURE_ONE, SHADER_TYPE::FRAGMENT_SHADER);
 
-    return m_pDescriptorSetLayoutMesh->finalize();
+    return m_pDescriptorSetLayoutMesh->finalize(m_pDevice);
 }
 
 bool MeshRenderer::createCommonDescriptorSet()
@@ -275,8 +275,8 @@ bool MeshRenderer::createCommonDescriptorSet()
         return false;
     }
 
-    m_pDescriptorSetCommon->writeUniformBufferDescriptor(SHADER_BINDING::PER_FRAME, m_pPointLightBuffer);
-    m_pDescriptorSetCommon->writeSamplerDescriptor(SHADER_BINDING::SAMPLER_ONE, m_pAniSampler);
+    m_pDescriptorSetCommon->updateUniformBufferDescriptor(SHADER_BINDING::PER_FRAME, m_pPointLightBuffer);
+    m_pDescriptorSetCommon->updateSamplerDescriptor(SHADER_BINDING::SAMPLER_ONE, m_pAniSampler);
     return true;
 }
 
@@ -430,7 +430,7 @@ void MeshRenderer::onMeshAdded(Entity entity)
 
     // Per-model descriptor set
     modelRenderResources.pDescriptorSet = m_pDevice->allocateDescriptorSet(m_pDescriptorSetLayoutModel);
-    modelRenderResources.pDescriptorSet->writeUniformBufferDescriptor(SHADER_BINDING::PER_OBJECT, modelRenderResources.pWVPBuffer);
+    modelRenderResources.pDescriptorSet->updateUniformBufferDescriptor(SHADER_BINDING::PER_OBJECT, modelRenderResources.pWVPBuffer);
 
     // Per-mesh resources
     for (const Mesh& mesh : pModel->Meshes) {
@@ -449,8 +449,8 @@ void MeshRenderer::onMeshAdded(Entity entity)
 
         // Create per-mesh descriptor set
         meshRenderResources.pDescriptorSet = m_pDevice->allocateDescriptorSet(m_pDescriptorSetLayoutMesh);
-        meshRenderResources.pDescriptorSet->writeUniformBufferDescriptor(SHADER_BINDING::MATERIAL_CONSTANTS, meshRenderResources.pMaterialBuffer);
-        meshRenderResources.pDescriptorSet->writeSampledTextureDescriptor(SHADER_BINDING::TEXTURE_ONE, material.textures[0].get());
+        meshRenderResources.pDescriptorSet->updateUniformBufferDescriptor(SHADER_BINDING::MATERIAL_CONSTANTS, meshRenderResources.pMaterialBuffer);
+        meshRenderResources.pDescriptorSet->updateSampledTextureDescriptor(SHADER_BINDING::TEXTURE_ONE, material.textures[0].get());
 
         modelRenderResources.MeshRenderResources.push_back(meshRenderResources);
     }

--- a/GameProject/Engine/UI/Panel.cpp
+++ b/GameProject/Engine/UI/Panel.cpp
@@ -186,7 +186,7 @@ bool UIHandler::createDescriptorSetLayout()
     m_pDescriptorSetLayout->addBindingUniformBuffer(SHADER_BINDING::PER_OBJECT, SHADER_TYPE::VERTEX_SHADER | SHADER_TYPE::FRAGMENT_SHADER);
     m_pDescriptorSetLayout->addBindingSampler(SHADER_BINDING::SAMPLER_ONE, SHADER_TYPE::FRAGMENT_SHADER);
     m_pDescriptorSetLayout->addBindingSampledTexture(SHADER_BINDING::TEXTURE_ONE, SHADER_TYPE::FRAGMENT_SHADER);
-    return m_pDescriptorSetLayout->finalize();
+    return m_pDescriptorSetLayout->finalize(m_pDevice);
 }
 
 bool UIHandler::createPipeline()
@@ -401,9 +401,9 @@ bool UIHandler::createPanelRenderResources(std::vector<AttachmentRenderResources
             return false;
         }
 
-        pDescriptorSet->writeUniformBufferDescriptor(SHADER_BINDING::PER_OBJECT, pPerAttachmentBuffer);
-        pDescriptorSet->writeSamplerDescriptor(SHADER_BINDING::SAMPLER_ONE, m_pAniSampler);
-        pDescriptorSet->writeSampledTextureDescriptor(SHADER_BINDING::TEXTURE_ONE, attachment.texture.get());
+        pDescriptorSet->updateUniformBufferDescriptor(SHADER_BINDING::PER_OBJECT, pPerAttachmentBuffer);
+        pDescriptorSet->updateSamplerDescriptor(SHADER_BINDING::SAMPLER_ONE, m_pAniSampler);
+        pDescriptorSet->updateSampledTextureDescriptor(SHADER_BINDING::TEXTURE_ONE, attachment.texture.get());
 
         renderResources.push_back({pDescriptorSet, pPerAttachmentBuffer});
     }

--- a/GameProject/Engine/UI/UIRenderer.cpp
+++ b/GameProject/Engine/UI/UIRenderer.cpp
@@ -151,7 +151,7 @@ bool UIRenderer::createDescriptorSetLayouts()
     }
 
     m_pDescriptorSetLayoutCommon->addBindingSampler(SHADER_BINDING::SAMPLER_ONE, SHADER_TYPE::FRAGMENT_SHADER);
-    if (!m_pDescriptorSetLayoutCommon->finalize()) {
+    if (!m_pDescriptorSetLayoutCommon->finalize(m_pDevice)) {
         return false;
     }
 
@@ -162,7 +162,7 @@ bool UIRenderer::createDescriptorSetLayouts()
 
     m_pDescriptorSetLayoutPanel->addBindingUniformBuffer(SHADER_BINDING::PER_OBJECT, SHADER_TYPE::VERTEX_SHADER | SHADER_TYPE::FRAGMENT_SHADER);
     m_pDescriptorSetLayoutPanel->addBindingSampledTexture(SHADER_BINDING::TEXTURE_ONE, SHADER_TYPE::FRAGMENT_SHADER);
-    return m_pDescriptorSetLayoutPanel->finalize();
+    return m_pDescriptorSetLayoutPanel->finalize(m_pDevice);
 }
 
 bool UIRenderer::createCommonDescriptorSet()
@@ -172,7 +172,7 @@ bool UIRenderer::createCommonDescriptorSet()
         return false;
     }
 
-    m_pDescriptorSetCommon->writeSamplerDescriptor(SHADER_BINDING::SAMPLER_ONE, m_pAniSampler);
+    m_pDescriptorSetCommon->updateSamplerDescriptor(SHADER_BINDING::SAMPLER_ONE, m_pAniSampler);
     return true;
 }
 
@@ -337,8 +337,8 @@ void UIRenderer::onPanelAdded(Entity entity)
         return;
     }
 
-    panelRenderResources.pDescriptorSet->writeUniformBufferDescriptor(SHADER_BINDING::PER_OBJECT, panelRenderResources.pBuffer);
-    panelRenderResources.pDescriptorSet->writeSampledTextureDescriptor(SHADER_BINDING::TEXTURE_ONE, panel.texture);
+    panelRenderResources.pDescriptorSet->updateUniformBufferDescriptor(SHADER_BINDING::PER_OBJECT, panelRenderResources.pBuffer);
+    panelRenderResources.pDescriptorSet->updateSampledTextureDescriptor(SHADER_BINDING::TEXTURE_ONE, panel.texture);
 
     m_PanelRenderResources.push_back(panelRenderResources, entity);
 }

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -185,6 +185,9 @@
     <ClCompile Include="Engine\Rendering\APIAbstractions\Vulkan\BufferVK.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\Vulkan\CommandListVK.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\Vulkan\CommandPoolVK.cpp" />
+    <ClCompile Include="Engine\Rendering\APIAbstractions\Vulkan\DescriptorPoolVK.cpp" />
+    <ClCompile Include="Engine\Rendering\APIAbstractions\Vulkan\DescriptorSetLayoutVK.cpp" />
+    <ClCompile Include="Engine\Rendering\APIAbstractions\Vulkan\DescriptorSetVK.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\Vulkan\DeviceCreatorVK.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\Vulkan\DeviceVK.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\Vulkan\FenceVK.cpp" />
@@ -296,6 +299,9 @@
     <ClInclude Include="Engine\Rendering\APIAbstractions\Vulkan\BufferVK.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\Vulkan\CommandListVK.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\Vulkan\CommandPoolVK.hpp" />
+    <ClInclude Include="Engine\Rendering\APIAbstractions\Vulkan\DescriptorPoolVK.hpp" />
+    <ClInclude Include="Engine\Rendering\APIAbstractions\Vulkan\DescriptorSetLayoutVK.hpp" />
+    <ClInclude Include="Engine\Rendering\APIAbstractions\Vulkan\DescriptorSetVK.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\Vulkan\DeviceCreatorVK.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\Vulkan\DeviceVK.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\Vulkan\FenceVK.hpp" />


### PR DESCRIPTION
Adds `DescriptorSetVK`, `DescriptorPoolVK` and `DescriptorSetLayoutVK`. `DescriptorSetVK` is however dependent on `SamplerVK`, and has two commented lines of code that need to be uncommented when `SamplerVK` is in place.