### PR TITLE
Remove redundant classes

### DIFF
--- a/GameProject/Engine/EnginePCH.hpp
+++ b/GameProject/Engine/EnginePCH.hpp
@@ -16,7 +16,7 @@
 #include <Engine/Rendering/APIAbstractions/IBuffer.hpp>
 #include <Engine/Rendering/APIAbstractions/ICommandList.hpp>
 #include <Engine/Rendering/APIAbstractions/InputLayout.hpp>
-#include <Engine/Rendering/APIAbstractions/IRasterizerState.hpp>
+#include <Engine/Rendering/APIAbstractions/RasterizerState.hpp>
 #include <Engine/Rendering/APIAbstractions/ISampler.hpp>
 #include <Engine/Rendering/APIAbstractions/Pipeline.hpp>
 #include <Engine/Rendering/APIAbstractions/PipelineLayout.hpp>

--- a/GameProject/Engine/Rendering/APIAbstractions/BlendState.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/BlendState.cpp
@@ -1,8 +1,0 @@
-#include "BlendState.hpp"
-
-#include <cstring>
-
-BlendState::BlendState(const float pBlendConstants[4])
-{
-    std::memcpy(m_pBlendConstants, pBlendConstants, sizeof(float) * 4u);
-}

--- a/GameProject/Engine/Rendering/APIAbstractions/BlendState.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/BlendState.hpp
@@ -57,15 +57,3 @@ struct BlendStateInfo {
     bool IndependentBlendEnabled;
     float pBlendConstants[4];
 };
-
-class BlendState
-{
-public:
-    BlendState(const float pBlendConstants[4]);
-    virtual ~BlendState() = 0 {};
-
-    const float* getBlendConstants() { return m_pBlendConstants; }
-
-private:
-    float m_pBlendConstants[4];
-};

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/BlendStateDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/BlendStateDX11.hpp
@@ -5,21 +5,12 @@
 #define NOMINMAX
 #include <d3d11.h>
 
-class BlendStateDX11 : public BlendState
-{
-public:
-    static BlendStateDX11* create(const BlendStateInfo& blendStateInfo, ID3D11Device* pDevice);
-
-public:
-    BlendStateDX11(ID3D11BlendState* pBlendState, const float pBlendConstants[4]);
-    ~BlendStateDX11();
-
-    ID3D11BlendState* getBlendState() { return m_pBlendState; }
-
-private:
-    static D3D11_BLEND convertBlendFactor(BLEND_FACTOR blendFactor);
-    static D3D11_BLEND_OP convertBlendOp(BLEND_OP blendOp);
-
-private:
-    ID3D11BlendState* m_pBlendState;
+struct BlendStateDX11 {
+    ID3D11BlendState* pBlendState;
+    float pBlendConstants[4];
 };
+
+bool createBlendState(BlendStateDX11& blendState, const BlendStateInfo& blendStateInfo, ID3D11Device* pDevice);
+
+D3D11_BLEND convertBlendFactor(BLEND_FACTOR blendFactor);
+D3D11_BLEND_OP convertBlendOp(BLEND_OP blendOp);

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DepthStencilStateDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DepthStencilStateDX11.hpp
@@ -5,24 +5,12 @@
 #define NOMINMAX
 #include <d3d11.h>
 
-class DepthStencilStateDX11 : public IDepthStencilState
-{
-public:
-    static DepthStencilStateDX11* create(const DepthStencilInfo& depthStencilInfo, ID3D11Device* pDevice);
-
-public:
-    DepthStencilStateDX11(ID3D11DepthStencilState* pDepthStencilState, UINT stencilReference);
-    ~DepthStencilStateDX11();
-
-    inline ID3D11DepthStencilState* getDepthStencilState() { return m_pDepthStencilState; }
-    inline UINT getStencilReference() const { return m_StencilReference; }
-
-private:
-    static D3D11_DEPTH_STENCILOP_DESC convertStencilOpInfo(const StencilOpInfo& stencilOpInfo);
-    static D3D11_STENCIL_OP convertStencilOp(STENCIL_OP stencilOp);
-
-private:
-    ID3D11DepthStencilState* m_pDepthStencilState;
-
-    UINT m_StencilReference;
+struct DepthStencilStateDX11 {
+    ID3D11DepthStencilState* pDepthStencilState;
+    UINT StencilReference;
 };
+
+bool createDepthStencilState(DepthStencilStateDX11& depthStencilState, const DepthStencilInfo& depthStencilInfo, ID3D11Device* pDevice);
+
+D3D11_DEPTH_STENCILOP_DESC convertStencilOpInfo(const StencilOpInfo& stencilOpInfo);
+D3D11_STENCIL_OP convertStencilOp(STENCIL_OP stencilOp);

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
@@ -121,11 +121,6 @@ RasterizerStateDX11* DeviceDX11::createRasterizerState(const RasterizerStateInfo
     return RasterizerStateDX11::create(rasterizerInfo, m_pDevice);
 }
 
-DepthStencilStateDX11* DeviceDX11::createDepthStencilState(const DepthStencilInfo& depthStencilInfo)
-{
-    return DepthStencilStateDX11::create(depthStencilInfo, m_pDevice);
-}
-
 BlendStateDX11* DeviceDX11::createBlendState(const BlendStateInfo& blendStateInfo)
 {
     return BlendStateDX11::create(blendStateInfo, m_pDevice);

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
@@ -121,11 +121,6 @@ RasterizerStateDX11* DeviceDX11::createRasterizerState(const RasterizerStateInfo
     return RasterizerStateDX11::create(rasterizerInfo, m_pDevice);
 }
 
-BlendStateDX11* DeviceDX11::createBlendState(const BlendStateInfo& blendStateInfo)
-{
-    return BlendStateDX11::create(blendStateInfo, m_pDevice);
-}
-
 DescriptorPoolDX11* DeviceDX11::createDescriptorPool(const DescriptorPoolInfo& poolInfo)
 {
     return DBG_NEW DescriptorPoolDX11(poolInfo);

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
@@ -116,11 +116,6 @@ SamplerDX11* DeviceDX11::createSampler(const SamplerInfo& samplerInfo)
     return SamplerDX11::create(samplerInfo, m_pDevice);
 }
 
-RasterizerStateDX11* DeviceDX11::createRasterizerState(const RasterizerStateInfo& rasterizerInfo)
-{
-    return RasterizerStateDX11::create(rasterizerInfo, m_pDevice);
-}
-
 DescriptorPoolDX11* DeviceDX11::createDescriptorPool(const DescriptorPoolInfo& poolInfo)
 {
     return DBG_NEW DescriptorPoolDX11(poolInfo);

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
@@ -65,9 +65,6 @@ public:
 
     std::string getShaderFileExtension() override final { return ".hlsl"; }
 
-    // Rasterizer
-    RasterizerStateDX11* createRasterizerState(const RasterizerStateInfo& rasterizerInfo) override final;
-
     bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) override final { return true; }
 
     ID3D11Device* getDevice()           { return m_pDevice; }

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
@@ -70,7 +70,6 @@ public:
 
     // Output merger
     BlendStateDX11* createBlendState(const BlendStateInfo& blendStateInfo) override final;
-    DepthStencilStateDX11* createDepthStencilState(const DepthStencilInfo& depthStencilInfo) override final;
 
     bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) override final { return true; }
 

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
@@ -68,9 +68,6 @@ public:
     // Rasterizer
     RasterizerStateDX11* createRasterizerState(const RasterizerStateInfo& rasterizerInfo) override final;
 
-    // Output merger
-    BlendStateDX11* createBlendState(const BlendStateInfo& blendStateInfo) override final;
-
     bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) override final { return true; }
 
     ID3D11Device* getDevice()           { return m_pDevice; }

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.cpp
@@ -27,7 +27,10 @@ PipelineDX11* PipelineDX11::create(const PipelineInfo& pipelineInfo, DeviceDX11*
     if (!createDepthStencilState(pipelineInfoDX.DepthStencilState, pipelineInfo.DepthStencilStateInfo, pDevice->getDevice())) {
         return nullptr;
     }
-    pipelineInfoDX.pBlendState = pDevice->createBlendState(pipelineInfo.BlendStateInfo);
+
+    if (!createBlendState(pipelineInfoDX.BlendState, pipelineInfo.BlendStateInfo, pDevice->getDevice())) {
+        return nullptr;
+    }
 
     return DBG_NEW PipelineDX11(pipelineInfoDX);
 }
@@ -68,7 +71,7 @@ PipelineDX11::~PipelineDX11()
 {
     delete m_PipelineInfo.pRasterizerState;
     SAFERELEASE(m_PipelineInfo.DepthStencilState.pDepthStencilState)
-    delete m_PipelineInfo.pBlendState;
+    SAFERELEASE(m_PipelineInfo.BlendState.pBlendState)
 }
 
 void PipelineDX11::bind(ID3D11DeviceContext* pContext)
@@ -86,7 +89,6 @@ void PipelineDX11::bind(ID3D11DeviceContext* pContext)
     pContext->RSSetState(m_PipelineInfo.pRasterizerState->getRasterizerState());
     pContext->RSSetViewports((UINT)m_PipelineInfo.Viewports.size(), (const D3D11_VIEWPORT*)m_PipelineInfo.Viewports.data());
 
-    BlendStateDX11* pBlendState                 = m_PipelineInfo.pBlendState;
     pContext->OMSetDepthStencilState(m_PipelineInfo.DepthStencilState.pDepthStencilState, m_PipelineInfo.DepthStencilState.StencilReference);
-    pContext->OMSetBlendState(pBlendState->getBlendState(), pBlendState->getBlendConstants(), D3D11_COLOR_WRITE_ENABLE_ALL);
+    pContext->OMSetBlendState(m_PipelineInfo.BlendState.pBlendState, m_PipelineInfo.BlendState.pBlendConstants, D3D11_COLOR_WRITE_ENABLE_ALL);
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.cpp
@@ -22,8 +22,12 @@ PipelineDX11* PipelineDX11::create(const PipelineInfo& pipelineInfo, DeviceDX11*
 
     pipelineInfoDX.Shaders.shrink_to_fit();
 
-    pipelineInfoDX.Viewports            = pipelineInfo.Viewports;
-    pipelineInfoDX.pRasterizerState     = pDevice->createRasterizerState(pipelineInfo.RasterizerStateInfo);
+    pipelineInfoDX.Viewports        = pipelineInfo.Viewports;
+
+    if (!createRasterizerState(pipelineInfoDX.RasterizerState, pipelineInfo.RasterizerStateInfo, pDevice->getDevice())) {
+        return nullptr;
+    }
+
     if (!createDepthStencilState(pipelineInfoDX.DepthStencilState, pipelineInfo.DepthStencilStateInfo, pDevice->getDevice())) {
         return nullptr;
     }
@@ -69,7 +73,7 @@ PipelineDX11::PipelineDX11(const PipelineInfoDX11& pipelineInfo)
 
 PipelineDX11::~PipelineDX11()
 {
-    delete m_PipelineInfo.pRasterizerState;
+    SAFERELEASE(m_PipelineInfo.RasterizerState.pRasterizerState)
     SAFERELEASE(m_PipelineInfo.DepthStencilState.pDepthStencilState)
     SAFERELEASE(m_PipelineInfo.BlendState.pBlendState)
 }
@@ -86,7 +90,7 @@ void PipelineDX11::bind(ID3D11DeviceContext* pContext)
     pContext->IASetInputLayout(pInputLayout->getInputLayout());
     pContext->IASetPrimitiveTopology(m_PipelineInfo.PrimitiveTopology);
 
-    pContext->RSSetState(m_PipelineInfo.pRasterizerState->getRasterizerState());
+    pContext->RSSetState(m_PipelineInfo.RasterizerState.pRasterizerState);
     pContext->RSSetViewports((UINT)m_PipelineInfo.Viewports.size(), (const D3D11_VIEWPORT*)m_PipelineInfo.Viewports.data());
 
     pContext->OMSetDepthStencilState(m_PipelineInfo.DepthStencilState.pDepthStencilState, m_PipelineInfo.DepthStencilState.StencilReference);

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.hpp
@@ -17,7 +17,7 @@ struct PipelineInfoDX11 {
     std::vector<std::shared_ptr<Shader>> Shaders;
     std::vector<Viewport> Viewports;
     RasterizerStateDX11* pRasterizerState;
-    DepthStencilStateDX11* pDepthStencilState;
+    DepthStencilStateDX11 DepthStencilState;
     BlendStateDX11* pBlendState;
 };
 

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.hpp
@@ -18,7 +18,7 @@ struct PipelineInfoDX11 {
     std::vector<Viewport> Viewports;
     RasterizerStateDX11* pRasterizerState;
     DepthStencilStateDX11 DepthStencilState;
-    BlendStateDX11* pBlendState;
+    BlendStateDX11 BlendState;
 };
 
 class DeviceDX11;

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.hpp
@@ -16,7 +16,7 @@ struct PipelineInfoDX11 {
     std::shared_ptr<VertexStage> VertexStage;
     std::vector<std::shared_ptr<Shader>> Shaders;
     std::vector<Viewport> Viewports;
-    RasterizerStateDX11* pRasterizerState;
+    RasterizerStateDX11 RasterizerState;
     DepthStencilStateDX11 DepthStencilState;
     BlendStateDX11 BlendState;
 };

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/RasterizerStateDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/RasterizerStateDX11.cpp
@@ -4,8 +4,10 @@
 #include <Engine/Utils/DirectXUtils.hpp>
 #include <Engine/Utils/Logger.hpp>
 
-RasterizerStateDX11* RasterizerStateDX11::create(const RasterizerStateInfo& rasterizerInfo, ID3D11Device* pDevice)
+bool createRasterizerState(RasterizerStateDX11& rasterizerState, const RasterizerStateInfo& rasterizerInfo, ID3D11Device* pDevice)
 {
+    rasterizerState = {};
+
     D3D11_RASTERIZER_DESC rsDesc = {};
     rsDesc.FillMode = rasterizerInfo.PolygonMode == POLYGON_MODE::FILL ? D3D11_FILL_SOLID : D3D11_FILL_WIREFRAME;
 
@@ -33,18 +35,12 @@ RasterizerStateDX11* RasterizerStateDX11::create(const RasterizerStateInfo& rast
     rsDesc.AntialiasedLineEnable    = false;
     rsDesc.MultisampleEnable        = false;
 
-    ID3D11RasterizerState* pRsState = nullptr;
-    HRESULT hr = pDevice->CreateRasterizerState(&rsDesc, &pRsState);
+    HRESULT hr = pDevice->CreateRasterizerState(&rsDesc, &rasterizerState.pRasterizerState);
     if (FAILED(hr)) {
         LOG_ERROR("Failed to create rasterizer state");
-        SAFERELEASE(pRsState)
-        return nullptr;
+        SAFERELEASE(rasterizerState.pRasterizerState)
+        return false;
     }
 
-    return DBG_NEW RasterizerStateDX11(pRsState);
-}
-
-RasterizerStateDX11::~RasterizerStateDX11()
-{
-    SAFERELEASE(m_pRasterizerState)
+    return true;
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/RasterizerStateDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/RasterizerStateDX11.hpp
@@ -1,21 +1,12 @@
 #pragma once
 
-#include <Engine/Rendering/APIAbstractions/IRasterizerState.hpp>
+#include <Engine/Rendering/APIAbstractions/RasterizerState.hpp>
 
 #define NOMINMAX
 #include <d3d11.h>
 
-class RasterizerStateDX11 : public IRasterizerState
-{
-public:
-    static RasterizerStateDX11* create(const RasterizerStateInfo& rasterizerInfo, ID3D11Device* pDevice);
-
-public:
-    RasterizerStateDX11(ID3D11RasterizerState* pRasterizerState) : m_pRasterizerState(pRasterizerState) {};
-    ~RasterizerStateDX11();
-
-    ID3D11RasterizerState* getRasterizerState() { return m_pRasterizerState; }
-
-private:
-    ID3D11RasterizerState* m_pRasterizerState;
+struct RasterizerStateDX11 {
+    ID3D11RasterizerState* pRasterizerState;
 };
+
+bool createRasterizerState(RasterizerStateDX11& rasterizerState, const RasterizerStateInfo& rasterizerInfo, ID3D11Device* pDevice);

--- a/GameProject/Engine/Rendering/APIAbstractions/DepthStencilState.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DepthStencilState.hpp
@@ -31,9 +31,3 @@ struct DepthStencilInfo {
     StencilOpInfo BackFace;
     uint32_t Reference;
 };
-
-class IDepthStencilState
-{
-public:
-    virtual ~IDepthStencilState() = 0 {};
-};

--- a/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
@@ -120,7 +120,6 @@ public:
 
     // Output merger
     virtual BlendState* createBlendState(const BlendStateInfo& blendStateInfo) = 0;
-    virtual IDepthStencilState* createDepthStencilState(const DepthStencilInfo& depthStencilInfo) = 0;
 
     // waitAll: Wait for every fence or just one. timeout: Nanoseconds
     virtual bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) = 0;

--- a/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
@@ -118,9 +118,6 @@ public:
     // Rasterizer
     virtual IRasterizerState* createRasterizerState(const RasterizerStateInfo& rasterizerInfo) = 0;
 
-    // Output merger
-    virtual BlendState* createBlendState(const BlendStateInfo& blendStateInfo) = 0;
-
     // waitAll: Wait for every fence or just one. timeout: Nanoseconds
     virtual bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) = 0;
 

--- a/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
@@ -115,9 +115,6 @@ public:
     Shader* createShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo = nullptr, InputLayout** ppInputLayout = nullptr);
     virtual std::string getShaderFileExtension() = 0;
 
-    // Rasterizer
-    virtual IRasterizerState* createRasterizerState(const RasterizerStateInfo& rasterizerInfo) = 0;
-
     // waitAll: Wait for every fence or just one. timeout: Nanoseconds
     virtual bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) = 0;
 

--- a/GameProject/Engine/Rendering/APIAbstractions/Pipeline.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Pipeline.hpp
@@ -3,7 +3,7 @@
 #include <Engine/Rendering/APIAbstractions/BlendState.hpp>
 #include <Engine/Rendering/APIAbstractions/DepthStencilState.hpp>
 #include <Engine/Rendering/APIAbstractions/InputLayout.hpp>
-#include <Engine/Rendering/APIAbstractions/IRasterizerState.hpp>
+#include <Engine/Rendering/APIAbstractions/RasterizerState.hpp>
 #include <Engine/Rendering/APIAbstractions/Shader.hpp>
 #include <Engine/Rendering/APIAbstractions/Viewport.hpp>
 

--- a/GameProject/Engine/Rendering/APIAbstractions/RasterizerState.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/RasterizerState.hpp
@@ -26,9 +26,3 @@ struct RasterizerStateInfo {
     float DepthBiasSlopeFactor;
     float LineWidth;
 };
-
-class IRasterizerState
-{
-public:
-    virtual ~IRasterizerState() = 0 {};
-};

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
@@ -75,8 +75,6 @@ public:
 
     IRasterizerState* createRasterizerState(const RasterizerStateInfo& rasterizerInfo) override final       { return nullptr; }
 
-    BlendState* createBlendState(const BlendStateInfo& blendStateInfo) override final                       { return nullptr; }
-
     bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) override final;
 
     VmaAllocator getVulkanAllocator()   { return m_Allocator; }

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
@@ -76,7 +76,6 @@ public:
     IRasterizerState* createRasterizerState(const RasterizerStateInfo& rasterizerInfo) override final       { return nullptr; }
 
     BlendState* createBlendState(const BlendStateInfo& blendStateInfo) override final                       { return nullptr; }
-    IDepthStencilState* createDepthStencilState(const DepthStencilInfo& depthStencilInfo) override final    { return nullptr; }
 
     bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) override final;
 

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
@@ -73,8 +73,6 @@ public:
 
     std::string getShaderFileExtension() override final { return ".spv"; }
 
-    IRasterizerState* createRasterizerState(const RasterizerStateInfo& rasterizerInfo) override final       { return nullptr; }
-
     bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) override final;
 
     VmaAllocator getVulkanAllocator()   { return m_Allocator; }

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -155,7 +155,6 @@
     <ClCompile Include="Engine\InputHandler.cpp" />
     <ClCompile Include="Engine\Physics\PhysicsCore.cpp" />
     <ClCompile Include="Engine\Physics\Velocity.cpp" />
-    <ClCompile Include="Engine\Rendering\APIAbstractions\BlendState.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\DescriptorCounts.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\DescriptorPool.cpp" />
     <ClCompile Include="Engine\Rendering\APIAbstractions\DescriptorPoolHandler.cpp" />
@@ -288,7 +287,7 @@
     <ClInclude Include="Engine\Rendering\APIAbstractions\Device.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\DX11\DeviceDX11.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\InputLayout.hpp" />
-    <ClInclude Include="Engine\Rendering\APIAbstractions\IRasterizerState.hpp" />
+    <ClInclude Include="Engine\Rendering\APIAbstractions\RasterizerState.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\ISampler.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\GeneralResources.hpp" />
     <ClInclude Include="Engine\Rendering\APIAbstractions\Pipeline.hpp" />


### PR DESCRIPTION
Rasterizer states, blend states and depth states are all just part of pipelines in vulkan, they are not separate objects. To match this structure, this merge request removes classes for rasterizer states, blend states and depth states.