### PR TITLE
InputLayout no longer a class

### DIFF
--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
@@ -121,7 +121,7 @@ DescriptorPoolDX11* DeviceDX11::createDescriptorPool(const DescriptorPoolInfo& p
     return DBG_NEW DescriptorPoolDX11(poolInfo);
 }
 
-ShaderDX11* DeviceDX11::compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo, InputLayout** ppInputLayout)
+ShaderDX11* DeviceDX11::compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo)
 {
     std::wstring filePathW(filePath.begin(), filePath.end());
     std::string targetVer = ShaderDX11::getTargetVersion(shaderType);
@@ -131,13 +131,9 @@ ShaderDX11* DeviceDX11::compileShader(SHADER_TYPE shaderType, const std::string&
         return nullptr;
     }
 
-    if (shaderType == SHADER_TYPE::VERTEX_SHADER && pInputLayoutInfo) {
-        *ppInputLayout = InputLayoutDX11::create(pInputLayoutInfo, pCompiledCode, m_pDevice);
-    }
-
     switch (shaderType) {
         case SHADER_TYPE::VERTEX_SHADER:
-            return ShaderDX11::createVertexShader(shaderType, pCompiledCode, filePath, m_pDevice);
+            return ShaderDX11::createVertexShader(shaderType, pCompiledCode, filePath, m_pDevice, pInputLayoutInfo);
         case SHADER_TYPE::HULL_SHADER:
             return ShaderDX11::createHullShader(shaderType, pCompiledCode, filePath, m_pDevice);
         case SHADER_TYPE::DOMAIN_SHADER:

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
@@ -74,7 +74,7 @@ protected:
     DescriptorPoolDX11* createDescriptorPool(const DescriptorPoolInfo& poolInfo) override final;
 
 private:
-    ShaderDX11* compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo, InputLayout** ppInputLayout) override final;
+    ShaderDX11* compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo) override final;
     bool executeCommandList(ICommandList* pCommandList);
 
 private:

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/InputLayoutDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/InputLayoutDX11.cpp
@@ -5,6 +5,40 @@
 #include <Engine/Utils/DirectXUtils.hpp>
 #include <Engine/Utils/Logger.hpp>
 
+
+bool createInputLayout(InputLayoutDX11& inputLayout, const InputLayoutInfo* pInputLayoutInfo, ID3DBlob* pShaderCode, ID3D11Device* pDevice)
+{
+    inputLayout = {};
+
+    std::vector<D3D11_INPUT_ELEMENT_DESC> attributeDescs(pInputLayoutInfo->VertexInputAttributes.size());
+    UINT attributeOffset = 0u;
+
+    for (size_t attributeIdx = 0; attributeIdx < attributeDescs.size(); attributeIdx++) {
+        D3D11_INPUT_ELEMENT_DESC& attributeDesc     = attributeDescs[attributeIdx];
+        const InputVertexAttribute& attributeInfo   = pInputLayoutInfo->VertexInputAttributes[attributeIdx];
+
+        attributeDesc.SemanticName          = (LPCSTR)attributeInfo.SemanticName.c_str();
+        attributeDesc.SemanticIndex         = 0u;
+        attributeDesc.Format                = convertFormatToDX(attributeInfo.Format);
+        attributeDesc.InputSlot             = (UINT)pInputLayoutInfo->Binding;
+        attributeDesc.AlignedByteOffset     = attributeOffset;
+        attributeDesc.InputSlotClass        = attributeInfo.InputRate == VERTEX_INPUT_RATE::PER_VERTEX ? D3D11_INPUT_PER_VERTEX_DATA : D3D11_INPUT_PER_INSTANCE_DATA;
+        attributeDesc.InstanceDataStepRate  = 0u;
+
+        attributeOffset += (UINT)getFormatSize(attributeInfo.Format);
+    }
+
+    HRESULT hr = pDevice->CreateInputLayout(attributeDescs.data(), (UINT)attributeDescs.size(), pShaderCode->GetBufferPointer(), pShaderCode->GetBufferSize(), &inputLayout.pInputLayout);
+    if (FAILED(hr)) {
+        LOG_ERROR("Failed to create input layout: %s", hresultToString(hr).c_str());
+        SAFERELEASE(inputLayout.pInputLayout)
+        return false;
+    }
+
+    inputLayout.VertexSize = attributeOffset;
+    return true;
+}
+
 D3D11_PRIMITIVE_TOPOLOGY convertPrimitiveTopology(PRIMITIVE_TOPOLOGY primitiveTopology)
 {
     switch (primitiveTopology) {
@@ -30,45 +64,4 @@ D3D11_PRIMITIVE_TOPOLOGY convertPrimitiveTopology(PRIMITIVE_TOPOLOGY primitiveTo
             LOG_ERROR("Erroneous primitive topology: %d", (int)primitiveTopology);
             return D3D11_PRIMITIVE_TOPOLOGY_UNDEFINED;
     }
-}
-
-InputLayoutDX11* InputLayoutDX11::create(const InputLayoutInfo* pInputLayoutInfo, ID3DBlob* pShaderCode, ID3D11Device* pDevice)
-{
-    std::vector<D3D11_INPUT_ELEMENT_DESC> attributeDescs(pInputLayoutInfo->VertexInputAttributes.size());
-    UINT attributeOffset = 0u;
-
-    for (size_t attributeIdx = 0; attributeIdx < attributeDescs.size(); attributeIdx++) {
-        D3D11_INPUT_ELEMENT_DESC& attributeDesc     = attributeDescs[attributeIdx];
-        const InputVertexAttribute& attributeInfo   = pInputLayoutInfo->VertexInputAttributes[attributeIdx];
-
-        attributeDesc.SemanticName          = (LPCSTR)attributeInfo.SemanticName.c_str();
-        attributeDesc.SemanticIndex         = 0u;
-        attributeDesc.Format                = convertFormatToDX(attributeInfo.Format);
-        attributeDesc.InputSlot             = (UINT)pInputLayoutInfo->Binding;
-        attributeDesc.AlignedByteOffset     = attributeOffset;
-        attributeDesc.InputSlotClass        = attributeInfo.InputRate == VERTEX_INPUT_RATE::PER_VERTEX ? D3D11_INPUT_PER_VERTEX_DATA : D3D11_INPUT_PER_INSTANCE_DATA;
-        attributeDesc.InstanceDataStepRate  = 0u;
-
-        attributeOffset += (UINT)getFormatSize(attributeInfo.Format);
-    }
-
-    ID3D11InputLayout* pInputLayout = nullptr;
-    HRESULT hr = pDevice->CreateInputLayout(attributeDescs.data(), (UINT)attributeDescs.size(), pShaderCode->GetBufferPointer(), pShaderCode->GetBufferSize(), &pInputLayout);
-    if (FAILED(hr)) {
-        LOG_ERROR("Failed to create input layout: %s", hresultToString(hr).c_str());
-        SAFERELEASE(pInputLayout)
-        return nullptr;
-    }
-
-    return DBG_NEW InputLayoutDX11(pInputLayout, (uint32_t)attributeOffset);
-}
-
-InputLayoutDX11::InputLayoutDX11(ID3D11InputLayout* pInputLayout, uint32_t vertexSize)
-    :InputLayout(vertexSize),
-    m_pInputLayout(pInputLayout)
-{}
-
-InputLayoutDX11::~InputLayoutDX11()
-{
-    SAFERELEASE(m_pInputLayout)
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/InputLayoutDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/InputLayoutDX11.hpp
@@ -5,19 +5,11 @@
 #define NOMINMAX
 #include <d3d11.h>
 
-D3D11_PRIMITIVE_TOPOLOGY convertPrimitiveTopology(PRIMITIVE_TOPOLOGY primitiveTopology);
-
-class InputLayoutDX11 : public InputLayout
-{
-public:
-    static InputLayoutDX11* create(const InputLayoutInfo* pInputLayoutInfo, ID3DBlob* pShaderCode, ID3D11Device* pDevice);
-
-public:
-    InputLayoutDX11(ID3D11InputLayout* pInputLayout, uint32_t vertexSize);
-    ~InputLayoutDX11();
-
-    inline ID3D11InputLayout* getInputLayout() { return m_pInputLayout; }
-
-private:
-    ID3D11InputLayout* m_pInputLayout;
+struct InputLayoutDX11 {
+    ID3D11InputLayout* pInputLayout;
+    UINT VertexSize;
 };
+
+bool createInputLayout(InputLayoutDX11& inputLayout, const InputLayoutInfo* pInputLayoutInfo, ID3DBlob* pShaderCode, ID3D11Device* pDevice);
+
+D3D11_PRIMITIVE_TOPOLOGY convertPrimitiveTopology(PRIMITIVE_TOPOLOGY primitiveTopology);

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.hpp
@@ -13,7 +13,6 @@
 
 struct PipelineInfoDX11 {
     D3D11_PRIMITIVE_TOPOLOGY PrimitiveTopology;
-    std::shared_ptr<VertexStage> VertexStage;
     std::vector<std::shared_ptr<Shader>> Shaders;
     std::vector<Viewport> Viewports;
     RasterizerStateDX11 RasterizerState;
@@ -36,7 +35,7 @@ public:
 
     void bind(ID3D11DeviceContext* pContext);
 
-    UINT getVertexSize() const { return (UINT)m_PipelineInfo.VertexStage.get()->getInputLayout()->getVertexSize(); }
+    UINT getVertexSize() const { return m_pInputLayout->VertexSize; }
 
 private:
     PipelineInfoDX11 m_PipelineInfo;
@@ -47,4 +46,6 @@ private:
     ID3D11DomainShader* m_pDomainShader;
     ID3D11GeometryShader* m_pGeometryShader;
     ID3D11PixelShader* m_pFragmentShader;
+
+    InputLayoutDX11* m_pInputLayout;
 };

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/ShaderDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/ShaderDX11.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Engine/Rendering/APIAbstractions/DX11/InputLayoutDX11.hpp>
 #include <Engine/Rendering/APIAbstractions/Shader.hpp>
 
 #define NOMINMAX
@@ -11,7 +12,7 @@ class ShaderDX11 : public Shader
 public:
     static ID3DBlob* compileShader(LPCWSTR fileName, LPCSTR targetVer);
 
-    static ShaderDX11* createVertexShader(SHADER_TYPE shaderType, ID3DBlob* pCompiledCode, const std::string& filePath, ID3D11Device* pDevice);
+    static ShaderDX11* createVertexShader(SHADER_TYPE shaderType, ID3DBlob* pCompiledCode, const std::string& filePath, ID3D11Device* pDevice, const InputLayoutInfo* pInputLayoutInfo);
     static ShaderDX11* createHullShader(SHADER_TYPE shaderType, ID3DBlob* pCompiledCode, const std::string& filePath, ID3D11Device* pDevice);
     static ShaderDX11* createDomainShader(SHADER_TYPE shaderType, ID3DBlob* pCompiledCode, const std::string& filePath, ID3D11Device* pDevice);
     static ShaderDX11* createGeometryShader(SHADER_TYPE shaderType, ID3DBlob* pCompiledCode, const std::string& filePath, ID3D11Device* pDevice);
@@ -22,7 +23,7 @@ public:
 
 public:
     ShaderDX11(SHADER_TYPE shaderType, ID3D11VertexShader* m_pVertexShader, ID3D11HullShader* m_pHullShader,
-        ID3D11DomainShader* m_pDomainShader, ID3D11GeometryShader* m_pGeometryShader, ID3D11PixelShader* m_pFragmentShader);
+        ID3D11DomainShader* m_pDomainShader, ID3D11GeometryShader* m_pGeometryShader, ID3D11PixelShader* m_pFragmentShader, InputLayoutDX11* pInputLayout = nullptr);
     ~ShaderDX11();
 
     inline ID3D11VertexShader* getVertexShader()        { return m_pVertexShader; }
@@ -31,10 +32,14 @@ public:
     inline ID3D11GeometryShader* getGeometryShader()    { return m_pGeometryShader; }
     inline ID3D11PixelShader* getFragmentShader()       { return m_pFragmentShader; }
 
+    inline InputLayoutDX11* getInputLayout() { return &m_InputLayout; }
+
 private:
     ID3D11VertexShader*     m_pVertexShader;
     ID3D11HullShader*       m_pHullShader;
     ID3D11DomainShader*     m_pDomainShader;
     ID3D11GeometryShader*   m_pGeometryShader;
     ID3D11PixelShader*      m_pFragmentShader;
+
+    InputLayoutDX11 m_InputLayout;
 };

--- a/GameProject/Engine/Rendering/APIAbstractions/Device.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Device.cpp
@@ -93,7 +93,7 @@ IBuffer* Device::createIndexBuffer(const unsigned* pIndices, size_t indexCount)
     return createBuffer(bufferInfo);
 }
 
-Shader* Device::createShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo, InputLayout** ppInputLayout)
+Shader* Device::createShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo)
 {
     // Create full path to shader file
     // Base shaders folder + relative path and name of shader + postfix and file extension
@@ -101,7 +101,7 @@ Shader* Device::createShader(SHADER_TYPE shaderType, const std::string& filePath
     Shader* pShader = nullptr;
 
     do {
-        pShader = compileShader(shaderType, shaderPath, pInputLayoutInfo, ppInputLayout);
+        pShader = compileShader(shaderType, shaderPath, pInputLayoutInfo);
 
         if (!pShader) {
             LOG_ERROR("Failed to compile [%s]", shaderPath.c_str());
@@ -109,10 +109,6 @@ Shader* Device::createShader(SHADER_TYPE shaderType, const std::string& filePath
             std::getchar();
         }
     } while (!pShader);
-
-    if (ppInputLayout && !*ppInputLayout) {
-        LOG_ERROR("Failed to create input layout, shader: %s", filePath.c_str());
-    }
 
     return pShader;
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
@@ -112,7 +112,7 @@ public:
     virtual ISampler* createSampler(const SamplerInfo& samplerInfo) = 0;
 
     // Shader's file path excludes the base path to the shaders folder
-    Shader* createShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo = nullptr, InputLayout** ppInputLayout = nullptr);
+    Shader* createShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo);
     virtual std::string getShaderFileExtension() = 0;
 
     // waitAll: Wait for every fence or just one. timeout: Nanoseconds
@@ -135,7 +135,7 @@ protected:
     Texture* m_pDepthTexture;
 
 private:
-    virtual Shader* compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo, InputLayout** ppInputLayout) = 0;
+    virtual Shader* compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo) = 0;
 
     struct TempCommandPoolInfo {
         uint32_t queueFamilyIndex;

--- a/GameProject/Engine/Rendering/APIAbstractions/InputLayout.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/InputLayout.hpp
@@ -33,15 +33,3 @@ struct InputLayoutInfo {
     std::vector<InputVertexAttribute> VertexInputAttributes;
     uint32_t Binding;
 };
-
-class InputLayout
-{
-public:
-    InputLayout(uint32_t vertexSize) : m_VertexSize(vertexSize) {};
-    virtual ~InputLayout() = 0 {};
-
-    inline uint32_t getVertexSize() const { return m_VertexSize; }
-
-private:
-    uint32_t m_VertexSize;
-};

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.cpp
@@ -191,7 +191,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL DeviceVK::vulkanCallback(VkDebugUtilsMessageSever
     }
 }
 
-Shader* DeviceVK::compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo, InputLayout** ppInputLayout)
+Shader* DeviceVK::compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo)
 {
     return ShaderVK::compileShader(filePath, shaderType, this);
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
@@ -86,7 +86,7 @@ private:
     static VKAPI_ATTR VkBool32 VKAPI_CALL vulkanCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData);
 
 private:
-    Shader* compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo, InputLayout** ppInputLayout) override final;
+    Shader* compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo) override final;
     bool executeCommandBuffer(VkQueue queue, ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo);
 
 private:

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.hpp
@@ -27,8 +27,8 @@ public:
 
     bool convertTextureLayout(VkCommandBuffer commandBuffer, TEXTURE_LAYOUT oldLayout, TEXTURE_LAYOUT newLayout, PIPELINE_STAGE srcStage, PIPELINE_STAGE dstStage);
 
-    inline VkImage getImage()           { return m_Image; }
-    inline VkImageView getImageView()   { return m_ImageView; } const
+    inline VkImage getImage()               { return m_Image; }
+    inline VkImageView getImageView() const { return m_ImageView; }
 
 private:
     static bool setInitialData(TextureVK* pTexture, const TextureInfoVK& textureInfo, DeviceVK* pDevice);

--- a/GameProject/Engine/Rendering/ShaderHandler.hpp
+++ b/GameProject/Engine/Rendering/ShaderHandler.hpp
@@ -6,28 +6,6 @@
 #include <memory>
 #include <unordered_map>
 
-class VertexStage
-{
-public:
-    VertexStage(InputLayout* pInputLayout, Shader* pVertexShader)
-        :m_pInputLayout(pInputLayout),
-        m_pVertexShader(pVertexShader)
-    {}
-
-    ~VertexStage()
-    {
-        delete m_pInputLayout;
-        delete m_pVertexShader;
-    }
-
-    InputLayout* getInputLayout() const { return m_pInputLayout; }
-    Shader* getVertexShader() const { return m_pVertexShader; }
-
-private:
-    InputLayout* m_pInputLayout;
-    Shader* m_pVertexShader;
-};
-
 class Device;
 
 class ShaderHandler
@@ -36,15 +14,11 @@ public:
     ShaderHandler(Device* pDevice);
     ~ShaderHandler() = default;
 
-    // The shader path must not include the path to the base Shaders folder
-    std::shared_ptr<VertexStage> loadVertexStage(const std::string& shaderPath);
     std::shared_ptr<Shader> loadShader(const std::string& shaderPath, SHADER_TYPE shaderType);
 
 private:
     // Mapping of vertex shader names to their input layout infos
     std::unordered_map<std::string, InputLayoutInfo> m_InputLayoutInfos;
-    std::unordered_map<std::string, std::weak_ptr<VertexStage>> m_VertexStageCache;
-    // Stores all shader types except vertex shaders, they are stored in the above hash map
     std::unordered_map<std::string, std::weak_ptr<Shader>> m_ShaderCache;
 
     Device* m_pDevice;


### PR DESCRIPTION
Since Vulkan doesn't have input layout objects (at least not exposed through the API), it doesn't make sense for the abstraction layer to have an input layout class.