### PR TITLE
Fix various vulkan issues

### DIFF
--- a/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Device.hpp
@@ -101,7 +101,8 @@ public:
     virtual ISemaphore* createSemaphore() = 0;
 
     // Shader resources
-    // pStagingResources is only needed if the buffer has initial data and is not CPU-writable
+    // pStagingResources can be used if the buffer has initial data and is not CPU-writable.
+    // If the staging resources are needed but none are specified, temporary ones are created.
     virtual IBuffer* createBuffer(const BufferInfo& bufferInfo, StagingResources* pStagingResources = nullptr) = 0;
     IBuffer* createVertexBuffer(const void* pVertices, size_t vertexSize, size_t vertexCount);
     IBuffer* createIndexBuffer(const unsigned* pIndices, size_t indexCount);

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/CommandPoolVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/CommandPoolVK.cpp
@@ -39,7 +39,7 @@ bool CommandPoolVK::allocateCommandLists(ICommandList** ppCommandLists, uint32_t
     allocationInfo.commandPool          = m_CommandPool;
     allocationInfo.level                = level == COMMAND_LIST_LEVEL::PRIMARY ? VK_COMMAND_BUFFER_LEVEL_PRIMARY : VK_COMMAND_BUFFER_LEVEL_SECONDARY;
     allocationInfo.commandBufferCount   = commandListCount;
-    if (vkAllocateCommandBuffers(m_pDevice->getDevice(), nullptr, commandBuffers.data()) != VK_SUCCESS) {
+    if (vkAllocateCommandBuffers(m_pDevice->getDevice(), &allocationInfo, commandBuffers.data()) != VK_SUCCESS) {
         LOG_ERROR("Failed to allocate [%d] command list(s)", commandListCount);
         return false;
     }

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceCreatorVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceCreatorVK.cpp
@@ -178,7 +178,8 @@ bool DeviceCreatorVK::pickPhysicalDevice()
         vkGetPhysicalDeviceFeatures(device, &deviceFeatures);
 
         deviceRating += VK_VERSION_MAJOR(deviceProperties.apiVersion) * 100u + VK_VERSION_MINOR(deviceProperties.apiVersion) * 10u;
-        deviceRating += uint32_t(deviceFeatures.geometryShader) * 100u;
+        deviceRating += uint32_t(deviceFeatures.geometryShader)     * 100u;
+        deviceRating += uint32_t(deviceFeatures.samplerAnisotropy)  * 100u;
         deviceRating += (deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) * 1000u;
 
         if (!verifyRequiredDeviceExtensionsSupported(device)) {
@@ -310,6 +311,7 @@ bool DeviceCreatorVK::initLogicalDevice()
     }
 
     VkPhysicalDeviceFeatures deviceFeatures = {};
+    deviceFeatures.samplerAnisotropy    = VK_TRUE;
 
     VkDeviceCreateInfo deviceInfo = {};
     deviceInfo.sType                    = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
@@ -65,6 +65,7 @@ public:
 
     // Shader resources
     BufferVK* createBuffer(const BufferInfo& bufferInfo, StagingResources* pStagingResources = nullptr) override final;
+    BufferVK* createStagingBuffer(const void* pData, VkDeviceSize size);
 
     Texture* createTextureFromFile(const std::string& filePath) override final;
     Texture* createTexture(const TextureInfo& textureInfo) override final;

--- a/GameProject/Engine/Utils/ResourcePool.hpp
+++ b/GameProject/Engine/Utils/ResourcePool.hpp
@@ -25,7 +25,8 @@ protected:
     friend ResourcePool<ResourceType>;
     PooledResource(ResourceType* pResource, size_t poolIdx, ResourcePool<ResourceType>* pResourcePool)
         :m_pResource(pResource),
-        m_PoolIndex(poolIdx)
+        m_PoolIndex(poolIdx),
+        m_pResourcePool(pResourcePool)
     {}
 
 private:


### PR DESCRIPTION
Fixes:
- Allocation info argument was not being specified when allocating command lists in `CommandPoolVK.cpp`
- Enable the optional feature of anisotropic filtering
- Create temporary staging resources when buffer creation requires it and none are specified