### PR TITLE
Fix vulkan renderpass creation crashing

### DIFF
--- a/GameProject/Engine/Rendering/APIAbstractions/RenderPass.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/RenderPass.hpp
@@ -43,7 +43,7 @@ struct AttachmentReference {
 struct SubpassInfo {
     PIPELINE_BIND_POINT PipelineBindPoint;
     std::vector<AttachmentReference> ColorAttachments;
-    AttachmentReference DepthStencilAttachment;
+    AttachmentReference* pDepthStencilAttachment;
 };
 
 #define SUBPASS_EXTERNAL UINT32_MAX

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/GeneralResourcesVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/GeneralResourcesVK.cpp
@@ -2,7 +2,7 @@
 
 VkPipelineStageFlags convertPipelineStageFlags(PIPELINE_STAGE pipelineStageFlags)
 {
-    return
+    return (int)pipelineStageFlags == 0 ? 0 :
         HAS_FLAG(pipelineStageFlags, PIPELINE_STAGE::TOP_OF_PIPE) * VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT |
         HAS_FLAG(pipelineStageFlags, PIPELINE_STAGE::DRAW_INDIRECT) * VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT |
         HAS_FLAG(pipelineStageFlags, PIPELINE_STAGE::VERTEX_INPUT) * VK_PIPELINE_STAGE_VERTEX_INPUT_BIT |

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/RenderPassVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/RenderPassVK.hpp
@@ -19,7 +19,7 @@ public:
 
 private:
     static VkAttachmentDescription convertAttachmentInfo(const AttachmentInfo& attachmentInfo);
-    static VkSubpassDescription convertSubpassInfo(const SubpassInfo& subpassInfo);
+    static VkSubpassDescription convertSubpassInfo(const SubpassInfo& subpassInfo, std::vector<VkAttachmentReference>& attachmentReferencesColor);
     static VkSubpassDependency convertSubpassDependency(const SubpassDependency& subpassDependency);
 
     static VkSampleCountFlagBits convertSampleCount(uint32_t sampleCount);

--- a/GameProject/Engine/Rendering/MeshRenderer.cpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.cpp
@@ -314,7 +314,7 @@ bool MeshRenderer::createRenderPass()
     depthStencilRef.Layout              = TEXTURE_LAYOUT::DEPTH_ATTACHMENT;
 
     subpass.ColorAttachments        = { backbufferRef };
-    subpass.DepthStencilAttachment  = { depthStencilRef };
+    subpass.pDepthStencilAttachment = &depthStencilRef;
     subpass.PipelineBindPoint       = PIPELINE_BIND_POINT::GRAPHICS;
 
     // Subpass dependency

--- a/GameProject/Engine/UI/Panel.cpp
+++ b/GameProject/Engine/UI/Panel.cpp
@@ -141,8 +141,6 @@ void UIHandler::createButton(Entity entity, DirectX::XMFLOAT4 hoverHighlight, Di
 
 bool UIHandler::createRenderPass()
 {
-    RenderPassInfo renderPassInfo   = {};
-
     // Render pass attachments
     AttachmentInfo panelTextureAttachment   = {};
     panelTextureAttachment.Format           = g_PanelTextureFormat;
@@ -153,24 +151,25 @@ bool UIHandler::createRenderPass()
     panelTextureAttachment.FinalLayout      = TEXTURE_LAYOUT::SHADER_READ_ONLY;
 
     // Subpass
-    SubpassInfo subpass = {};
     AttachmentReference panelTextureRef = {};
     panelTextureRef.AttachmentIndex     = 0u;
     panelTextureRef.Layout              = TEXTURE_LAYOUT::RENDER_TARGET;
 
+    SubpassInfo subpass = {};
     subpass.ColorAttachments    = { panelTextureRef };
     subpass.PipelineBindPoint   = PIPELINE_BIND_POINT::GRAPHICS;
 
     // Subpass dependency
     SubpassDependency subpassDependency = {};
     subpassDependency.SrcSubpass        = SUBPASS_EXTERNAL;
-    subpassDependency.DstSubpass        = 0;
+    subpassDependency.DstSubpass        = 0u;
     subpassDependency.SrcStage          = PIPELINE_STAGE::BOTTOM_OF_PIPE;
     subpassDependency.DstStage          = PIPELINE_STAGE::COLOR_ATTACHMENT_OUTPUT;
-    subpassDependency.SrcAccessMask     = RESOURCE_ACCESS::SHADER_READ;
+    subpassDependency.SrcAccessMask     = (RESOURCE_ACCESS)(0);
     subpassDependency.DstAccessMask     = RESOURCE_ACCESS::COLOR_ATTACHMENT_READ | RESOURCE_ACCESS::COLOR_ATTACHMENT_WRITE;
     subpassDependency.DependencyFlags   = DEPENDENCY_FLAG::BY_REGION;
 
+    RenderPassInfo renderPassInfo   = {};
     renderPassInfo.AttachmentInfos  = { panelTextureAttachment };
     renderPassInfo.Subpasses        = { subpass };
     renderPassInfo.Dependencies     = { subpassDependency };

--- a/GameProject/Engine/UI/UIRenderer.cpp
+++ b/GameProject/Engine/UI/UIRenderer.cpp
@@ -210,7 +210,7 @@ bool UIRenderer::createRenderPass()
     depthStencilRef.Layout              = TEXTURE_LAYOUT::DEPTH_ATTACHMENT;
 
     subpass.ColorAttachments        = { backbufferRef };
-    subpass.DepthStencilAttachment  = { depthStencilRef };
+    subpass.pDepthStencilAttachment = &depthStencilRef;
     subpass.PipelineBindPoint       = PIPELINE_BIND_POINT::GRAPHICS;
 
     // Subpass dependency


### PR DESCRIPTION
- VK_SUBPASS_EXTERNAL should be accompanied by a 0 as srcAccessMask
- Subpass descriptions were using pointers to local variables that were destroyed before the renderpass was created