### PR TITLE
Various vulkan fixes

### DIFF
--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetDX11.hpp
@@ -13,7 +13,7 @@ class TextureDX11;
 
 template <typename Resource>
 struct Binding {
-    Resource* pResource;
+    Resource Resource;
     UINT Binding;
     SHADER_TYPE ShaderStages;
 };
@@ -25,15 +25,13 @@ public:
     ~DescriptorSetDX11() = default;
 
     void updateUniformBufferDescriptor(SHADER_BINDING binding, IBuffer* pBuffer) override final;
-    void updateSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture) override final;
-    void updateSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler) override final;
+    void updateCombinedTextureSamplerDescriptor(SHADER_BINDING binding, Texture* pTexture, ISampler* pSampler) override final;
 
     void bind(ID3D11DeviceContext* pContext);
 
 private:
-    std::vector<Binding<ID3D11Buffer>> m_BufferBindings;
-    std::vector<Binding<ID3D11ShaderResourceView>> m_SampledTextureBindings;
-    std::vector<Binding<ID3D11SamplerState>> m_SamplerBindings;
+    std::vector<Binding<ID3D11Buffer*>> m_BufferBindings;
+    std::vector<Binding<std::pair<ID3D11ShaderResourceView*, ID3D11SamplerState*>>> m_CombinedTextureSamplerBindings;
 
     // Contains information on which shaders the bindings belong to
     const DescriptorSetLayoutDX11* m_pLayout;

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetLayoutDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetLayoutDX11.cpp
@@ -7,34 +7,25 @@ void DescriptorSetLayoutDX11::addBindingUniformBuffer(SHADER_BINDING binding, SH
     m_UniformBufferSlots.push_back({bindingU, shaderStages});
 }
 
-void DescriptorSetLayoutDX11::addBindingSampledTexture(SHADER_BINDING binding, SHADER_TYPE shaderStages)
+void DescriptorSetLayoutDX11::addBindingCombinedTextureSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages)
 {
     uint32_t bindingU = (uint32_t)binding;
     m_BindingShaderMap[bindingU] = shaderStages;
-    m_SampledTextureSlots.push_back({bindingU, shaderStages});
-}
-
-void DescriptorSetLayoutDX11::addBindingSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages)
-{
-    uint32_t bindingU = (uint32_t)binding;
-    m_BindingShaderMap[bindingU] = shaderStages;
-    m_SamplerSlots.push_back({bindingU, shaderStages});
+    m_CombinedTextureSamplerSlots.push_back({bindingU, shaderStages});
 }
 
 bool DescriptorSetLayoutDX11::finalize(Device* pDevice)
 {
     m_UniformBufferSlots.shrink_to_fit();
-    m_SampledTextureSlots.shrink_to_fit();
-    m_SamplerSlots.shrink_to_fit();
+    m_CombinedTextureSamplerSlots.shrink_to_fit();
     return true;
 }
 
 DescriptorCounts DescriptorSetLayoutDX11::getDescriptorCounts() const
 {
-    DescriptorCounts descriptorCounts       = {};
-    descriptorCounts.m_UniformBuffers       = (uint32_t)m_UniformBufferSlots.size();
-    descriptorCounts.m_SampledTextures      = (uint32_t)m_SampledTextureSlots.size();
-    descriptorCounts.m_Samplers             = (uint32_t)m_SamplerSlots.size();
+    DescriptorCounts descriptorCounts = {};
+    descriptorCounts.m_UniformBuffers           = (uint32_t)m_UniformBufferSlots.size();
+    descriptorCounts.m_CombinedTextureSamplers  = (uint32_t)m_CombinedTextureSamplerSlots.size();
 
     return descriptorCounts;
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetLayoutDX11.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/DescriptorSetLayoutDX11.hpp
@@ -17,8 +17,7 @@ public:
     ~DescriptorSetLayoutDX11() = default;
 
     void addBindingUniformBuffer(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
-    void addBindingSampledTexture(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
-    void addBindingSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
+    void addBindingCombinedTextureSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
 
     bool finalize(Device* pDevice) override final;
 
@@ -28,8 +27,7 @@ public:
 
 private:
     std::vector<BindingSlot> m_UniformBufferSlots;
-    std::vector<BindingSlot> m_SampledTextureSlots;
-    std::vector<BindingSlot> m_SamplerSlots;
+    std::vector<BindingSlot> m_CombinedTextureSamplerSlots;
 
     // Maps binding slots to the shader stages they belong to
     std::unordered_map<uint32_t, SHADER_TYPE> m_BindingShaderMap;

--- a/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DX11/PipelineDX11.cpp
@@ -23,7 +23,7 @@ PipelineDX11* PipelineDX11::create(const PipelineInfo& pipelineInfo, DeviceDX11*
 
     pipelineInfoDX.Shaders.shrink_to_fit();
 
-    pipelineInfoDX.Viewports        = pipelineInfo.Viewports;
+    pipelineInfoDX.Viewports = pipelineInfo.Viewports;
 
     if (!createRasterizerState(&pipelineInfoDX.pRasterizerState, pipelineInfo.RasterizerStateInfo, pDevice->getDevice())) {
         return nullptr;

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorCounts.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorCounts.cpp
@@ -4,69 +4,60 @@
 
 DescriptorCounts::DescriptorCounts()
     :m_UniformBuffers(0),
-    m_SampledTextures(0),
-    m_Samplers(0)
+    m_CombinedTextureSamplers(0)
 {}
 
 DescriptorCounts& DescriptorCounts::operator+=(const DescriptorCounts& other)
 {
-    m_UniformBuffers    += other.m_UniformBuffers;
-    m_SampledTextures   += other.m_SampledTextures;
-    m_Samplers          += other.m_Samplers;
+    m_UniformBuffers            += other.m_UniformBuffers;
+    m_CombinedTextureSamplers   += other.m_CombinedTextureSamplers;
     return *this;
 }
 
 DescriptorCounts& DescriptorCounts::operator-=(const DescriptorCounts& other)
 {
     // Avoid underflow
-    m_UniformBuffers    = (uint32_t)std::max(0, (int)m_UniformBuffers - (int)other.m_UniformBuffers);
-    m_SampledTextures   = (uint32_t)std::max(0, (int)m_SampledTextures - (int)other.m_SampledTextures);
-    m_Samplers          = (uint32_t)std::max(0, (int)m_Samplers - (int)other.m_Samplers);
+    m_UniformBuffers            = (uint32_t)std::max(0, (int)m_UniformBuffers - (int)other.m_UniformBuffers);
+    m_CombinedTextureSamplers   = (uint32_t)std::max(0, (int)m_CombinedTextureSamplers - (int)other.m_CombinedTextureSamplers);
     return *this;
 }
 
 DescriptorCounts& DescriptorCounts::operator*=(uint32_t factor)
 {
-    m_UniformBuffers    *= factor;
-    m_SampledTextures   *= factor;
-    m_Samplers          *= factor;
+    m_UniformBuffers            *= factor;
+    m_CombinedTextureSamplers   *= factor;
     return *this;
 }
 
 void DescriptorCounts::ceil(const DescriptorCounts& other)
 {
-    m_UniformBuffers    = std::max(m_UniformBuffers, other.m_UniformBuffers);
-    m_SampledTextures   = std::max(m_SampledTextures, other.m_SampledTextures);
-    m_Samplers          = std::max(m_Samplers, other.m_Samplers);
+    m_UniformBuffers            = std::max(m_UniformBuffers, other.m_UniformBuffers);
+    m_CombinedTextureSamplers   = std::max(m_CombinedTextureSamplers, other.m_CombinedTextureSamplers);
 }
 
 void DescriptorCounts::setAll(uint32_t descriptorCount)
 {
-    m_UniformBuffers    = descriptorCount;
-    m_SampledTextures   = descriptorCount;
-    m_Samplers          = descriptorCount;
+    m_UniformBuffers            = descriptorCount;
+    m_CombinedTextureSamplers   = descriptorCount;
 }
 
 bool DescriptorCounts::contains(const DescriptorCounts& other) const
 {
     return
-        m_UniformBuffers    >= other.m_UniformBuffers &&
-        m_SampledTextures   >= other.m_SampledTextures &&
-        m_Samplers          >= other.m_Samplers;
+        m_UniformBuffers            >= other.m_UniformBuffers &&
+        m_CombinedTextureSamplers   >= other.m_CombinedTextureSamplers;
 }
 
 std::string DescriptorCounts::toString() const
 {
     return
-        "Uniform Buffers: "     + std::to_string(m_UniformBuffers) + ", " +
-        "Sampled Textures: "    + std::to_string(m_SampledTextures) + ", " +
-        "Samplers: "            + std::to_string(m_Samplers);
+        "Uniform Buffers: "             + std::to_string(m_UniformBuffers) + ", " +
+        "Combined texture samplers: "   + std::to_string(m_CombinedTextureSamplers);
 }
 
 uint32_t DescriptorCounts::getDescriptorTypeCount() const
 {
     return
-        m_UniformBuffers    != 0u +
-        m_SampledTextures   != 0u +
-        m_Samplers          != 0u;
+        m_UniformBuffers            != 0u +
+        m_CombinedTextureSamplers   != 0u;
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorCounts.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorCounts.hpp
@@ -27,6 +27,5 @@ public:
     uint32_t getDescriptorTypeCount() const;
 
     uint32_t m_UniformBuffers;
-    uint32_t m_SampledTextures;
-    uint32_t m_Samplers;
+    uint32_t m_CombinedTextureSamplers;
 };

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorSet.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorSet.hpp
@@ -15,8 +15,7 @@ public:
     virtual ~DescriptorSet();
 
     virtual void updateUniformBufferDescriptor(SHADER_BINDING binding, IBuffer* pBuffer) = 0;
-    virtual void updateSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture) = 0;
-    virtual void updateSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler) = 0;
+    virtual void updateCombinedTextureSamplerDescriptor(SHADER_BINDING binding, Texture* pTexture, ISampler* pSampler) = 0;
 
     const IDescriptorSetLayout* getLayout() const { return m_pLayout; }
 

--- a/GameProject/Engine/Rendering/APIAbstractions/DescriptorSetLayout.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/DescriptorSetLayout.hpp
@@ -14,8 +14,7 @@ public:
     virtual bool finalize(Device* pDevice) = 0;
 
     virtual void addBindingUniformBuffer(SHADER_BINDING binding, SHADER_TYPE shaderStages) = 0;
-    virtual void addBindingSampledTexture(SHADER_BINDING binding, SHADER_TYPE shaderStages) = 0;
-    virtual void addBindingSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages) = 0;
+    virtual void addBindingCombinedTextureSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages) = 0;
 
     // How many descriptors of each type are involved in the layout
     virtual DescriptorCounts getDescriptorCounts() const = 0;

--- a/GameProject/Engine/Rendering/APIAbstractions/Pipeline.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Pipeline.hpp
@@ -16,7 +16,8 @@ struct ShaderInfo {
 };
 
 enum class PIPELINE_DYNAMIC_STATE {
-    VIEWPORT
+    VIEWPORT,
+    SCISSOR
 };
 
 class IPipelineLayout;

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.cpp
@@ -21,18 +21,11 @@ DescriptorPoolVK* DescriptorPoolVK::create(const DescriptorPoolInfo& poolInfo, D
         descriptorCounts.push_back(uniformPool);
     }
 
-    if (poolInfo.DescriptorCounts.m_SampledTextures) {
+    if (poolInfo.DescriptorCounts.m_CombinedTextureSamplers) {
         VkDescriptorPoolSize sampledTexturesPool = {};
         sampledTexturesPool.type            = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-        sampledTexturesPool.descriptorCount = poolInfo.DescriptorCounts.m_SampledTextures;
+        sampledTexturesPool.descriptorCount = poolInfo.DescriptorCounts.m_CombinedTextureSamplers;
         descriptorCounts.push_back(sampledTexturesPool);
-    }
-
-    if (poolInfo.DescriptorCounts.m_Samplers) {
-        VkDescriptorPoolSize samplersPool = {};
-        samplersPool.type            = VK_DESCRIPTOR_TYPE_SAMPLER;
-        samplersPool.descriptorCount = poolInfo.DescriptorCounts.m_Samplers;
-        descriptorCounts.push_back(samplersPool);
     }
 
     poolCreateInfo.pPoolSizes = descriptorCounts.data();

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.cpp
@@ -31,14 +31,9 @@ void DescriptorSetLayoutVK::addBindingUniformBuffer(SHADER_BINDING binding, SHAD
     addBinding((uint32_t)binding, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, shaderStages);
 }
 
-void DescriptorSetLayoutVK::addBindingSampledTexture(SHADER_BINDING binding, SHADER_TYPE shaderStages)
+void DescriptorSetLayoutVK::addBindingCombinedTextureSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages)
 {
-    addBinding((uint32_t)binding, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, shaderStages);
-}
-
-void DescriptorSetLayoutVK::addBindingSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages)
-{
-    addBinding((uint32_t)binding, VK_DESCRIPTOR_TYPE_SAMPLER, shaderStages);
+    addBinding((uint32_t)binding, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, shaderStages);
 }
 
 DescriptorCounts DescriptorSetLayoutVK::getDescriptorCounts() const
@@ -47,10 +42,8 @@ DescriptorCounts DescriptorSetLayoutVK::getDescriptorCounts() const
     for (const VkDescriptorSetLayoutBinding& binding : m_Bindings) {
         if (binding.descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) {
             descriptorCounts.m_UniformBuffers += 1u;
-        } else if (binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) {
-            descriptorCounts.m_SampledTextures += 1u;
-        } else if (binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER) {
-            descriptorCounts.m_Samplers += 1u;
+        } else if (binding.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
+            descriptorCounts.m_CombinedTextureSamplers += 1u;
         }
     }
 

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.cpp
@@ -8,13 +8,12 @@ bool DescriptorSetLayoutVK::finalize(Device* pDevice)
     m_pDevice = reinterpret_cast<DeviceVK*>(pDevice);
 
     VkDescriptorSetLayoutCreateInfo layoutInfo = {};
-    layoutInfo.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
+    layoutInfo.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
     layoutInfo.bindingCount = (uint32_t)m_Bindings.size();
     layoutInfo.pBindings    = m_Bindings.data();
 
     VkDevice device = reinterpret_cast<DeviceVK*>(pDevice)->getDevice();
-    VkDescriptorSetLayout layout = VK_NULL_HANDLE;
-    if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &layout) != VK_SUCCESS) {
+    if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &m_DescriptorSetLayout) != VK_SUCCESS) {
         LOG_ERROR("Failed to create descriptor set layout");
         return false;
     }

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetLayoutVK.hpp
@@ -20,8 +20,7 @@ public:
     bool finalize(Device* pDevice) override final;
 
     void addBindingUniformBuffer(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
-    void addBindingSampledTexture(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
-    void addBindingSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
+    void addBindingCombinedTextureSampler(SHADER_BINDING binding, SHADER_TYPE shaderStages) override final;
 
     DescriptorCounts getDescriptorCounts() const override final;
     inline VkDescriptorSetLayout getDescriptorSetLayout() const { return m_DescriptorSetLayout; }

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetVK.cpp
@@ -21,19 +21,12 @@ void DescriptorSetVK::updateUniformBufferDescriptor(SHADER_BINDING binding, IBuf
     updateDescriptor(binding, nullptr, &bufferInfo);
 }
 
-void DescriptorSetVK::updateSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture)
+void DescriptorSetVK::updateCombinedTextureSamplerDescriptor(SHADER_BINDING binding, Texture* pTexture, ISampler* pSampler)
 {
     VkDescriptorImageInfo imageInfo = {};
+    imageInfo.sampler       = reinterpret_cast<SamplerVK*>(pSampler)->getSampler();
     imageInfo.imageView     = reinterpret_cast<TextureVK*>(pTexture)->getImageView();
     imageInfo.imageLayout   = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
-    updateDescriptor(binding, &imageInfo, nullptr);
-}
-
-void DescriptorSetVK::updateSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler)
-{
-    VkDescriptorImageInfo imageInfo = {};
-    imageInfo.sampler = reinterpret_cast<SamplerVK*>(pSampler)->getSampler();
 
     updateDescriptor(binding, &imageInfo, nullptr);
 }

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DescriptorSetVK.hpp
@@ -15,8 +15,7 @@ public:
     ~DescriptorSetVK() = default;
 
     void updateUniformBufferDescriptor(SHADER_BINDING binding, IBuffer* pBuffer) override final;
-    void updateSampledTextureDescriptor(SHADER_BINDING binding, Texture* pTexture) override final;
-    void updateSamplerDescriptor(SHADER_BINDING binding, ISampler* pSampler) override final;
+    void updateCombinedTextureSamplerDescriptor(SHADER_BINDING binding, Texture* pTexture, ISampler* pSampler) override final;
 
     inline VkDescriptorSet getDescriptorSet() const { return m_DescriptorSet; }
 

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.cpp
@@ -8,6 +8,7 @@
 #include <Engine/Rendering/APIAbstractions/Vulkan/FramebufferVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/GeneralResourcesVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/PipelineLayoutVK.hpp>
+#include <Engine/Rendering/APIAbstractions/Vulkan/PipelineVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/RenderPassVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/SamplerVK.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/SemaphoreVK.hpp>
@@ -127,6 +128,11 @@ IRenderPass* DeviceVK::createRenderPass(const RenderPassInfo& renderPassInfo)
 IPipelineLayout* DeviceVK::createPipelineLayout(std::vector<IDescriptorSetLayout*> descriptorSetLayouts)
 {
     return PipelineLayoutVK::create(descriptorSetLayouts, this);
+}
+
+IPipeline* DeviceVK::createPipeline(const PipelineInfo& pipelineInfo)
+{
+    return PipelineVK::create(pipelineInfo, this);
 }
 
 FenceVK* DeviceVK::createFence(bool createSignaled)

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
@@ -55,7 +55,7 @@ public:
     IRenderPass* createRenderPass(const RenderPassInfo& renderPassInfo) override final;
 
     IPipelineLayout* createPipelineLayout(std::vector<IDescriptorSetLayout*> descriptorSetLayouts) override final;
-    IPipeline* createPipeline(const PipelineInfo& pipelineInfo) override final { return nullptr; }
+    IPipeline* createPipeline(const PipelineInfo& pipelineInfo) override final;
 
     void map(IBuffer* pBuffer, void** ppMappedMemory) override final;
     void unmap(IBuffer* pBuffer) override final;

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/InputLayoutVK.cpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/InputLayoutVK.cpp
@@ -3,12 +3,11 @@
 #include <Engine/Rendering/APIAbstractions/GeneralResources.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/GeneralResourcesVK.hpp>
 
-bool convertInputLayoutInfo(VkPipelineVertexInputStateCreateInfo& inputLayoutInfoVK, const InputLayoutInfo& inputLayoutInfo)
+bool convertInputLayoutInfo(VkPipelineVertexInputStateCreateInfo& inputLayoutInfoVK, std::vector<VkVertexInputAttributeDescription>& attributeDescs, const InputLayoutInfo& inputLayoutInfo)
 {
     uint32_t vertexOffset   = 0u;
     uint32_t location       = 0u;
 
-    std::vector<VkVertexInputAttributeDescription> attributeDescs;
     attributeDescs.reserve(inputLayoutInfo.VertexInputAttributes.size());
     for (const InputVertexAttribute& vertexAttribute : inputLayoutInfo.VertexInputAttributes) {
         vertexOffset += (uint32_t)getFormatSize(vertexAttribute.Format);

--- a/GameProject/Engine/Rendering/APIAbstractions/Vulkan/InputLayoutVK.hpp
+++ b/GameProject/Engine/Rendering/APIAbstractions/Vulkan/InputLayoutVK.hpp
@@ -4,4 +4,4 @@
 
 #include <vulkan/vulkan.h>
 
-bool convertInputLayoutInfo(VkPipelineVertexInputStateCreateInfo& inputLayoutInfoVK, const InputLayoutInfo& inputLayoutInfo);
+bool convertInputLayoutInfo(VkPipelineVertexInputStateCreateInfo& inputLayoutInfoVK, std::vector<VkVertexInputAttributeDescription>& attributeDescs, const InputLayoutInfo& inputLayoutInfo);

--- a/GameProject/Engine/Rendering/MeshRenderer.cpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.cpp
@@ -373,10 +373,11 @@ bool MeshRenderer::createPipeline()
     pipelineInfo.Viewports = { viewport };
 
     pipelineInfo.RasterizerStateInfo = {};
-    pipelineInfo.RasterizerStateInfo.PolygonMode          = POLYGON_MODE::FILL;
-    pipelineInfo.RasterizerStateInfo.CullMode             = CULL_MODE::BACK;
-    pipelineInfo.RasterizerStateInfo.FrontFaceOrientation = FRONT_FACE_ORIENTATION::CLOCKWISE;
-    pipelineInfo.RasterizerStateInfo.DepthBiasEnable      = false;
+    pipelineInfo.RasterizerStateInfo.PolygonMode            = POLYGON_MODE::FILL;
+    pipelineInfo.RasterizerStateInfo.CullMode               = CULL_MODE::BACK;
+    pipelineInfo.RasterizerStateInfo.FrontFaceOrientation   = FRONT_FACE_ORIENTATION::CLOCKWISE;
+    pipelineInfo.RasterizerStateInfo.DepthBiasEnable        = false;
+    pipelineInfo.RasterizerStateInfo.LineWidth              = 1.0f;
 
     pipelineInfo.DepthStencilStateInfo = {};
     pipelineInfo.DepthStencilStateInfo.DepthTestEnabled     = true;
@@ -400,6 +401,7 @@ bool MeshRenderer::createPipeline()
         blendConstant = 1.0f;
     }
 
+    pipelineInfo.DynamicStates  = { PIPELINE_DYNAMIC_STATE::SCISSOR };
     pipelineInfo.pLayout        = m_pPipelineLayout;
     pipelineInfo.pRenderPass    = m_pRenderPass;
     pipelineInfo.Subpass        = 0u;

--- a/GameProject/Engine/Rendering/MeshRenderer.cpp
+++ b/GameProject/Engine/Rendering/MeshRenderer.cpp
@@ -244,7 +244,6 @@ bool MeshRenderer::createDescriptorSetLayouts()
     m_pDescriptorSetLayoutCommon = m_pDevice->createDescriptorSetLayout();
 
     m_pDescriptorSetLayoutCommon->addBindingUniformBuffer(SHADER_BINDING::PER_FRAME, SHADER_TYPE::FRAGMENT_SHADER);
-    m_pDescriptorSetLayoutCommon->addBindingSampler(SHADER_BINDING::SAMPLER_ONE, SHADER_TYPE::FRAGMENT_SHADER);
 
     if (!m_pDescriptorSetLayoutCommon->finalize(m_pDevice)) {
         return false;
@@ -263,7 +262,7 @@ bool MeshRenderer::createDescriptorSetLayouts()
     m_pDescriptorSetLayoutMesh = m_pDevice->createDescriptorSetLayout();
 
     m_pDescriptorSetLayoutMesh->addBindingUniformBuffer(SHADER_BINDING::MATERIAL_CONSTANTS, SHADER_TYPE::FRAGMENT_SHADER);
-    m_pDescriptorSetLayoutMesh->addBindingSampledTexture(SHADER_BINDING::TEXTURE_ONE, SHADER_TYPE::FRAGMENT_SHADER);
+    m_pDescriptorSetLayoutMesh->addBindingCombinedTextureSampler(SHADER_BINDING::TEXTURE_ONE, SHADER_TYPE::FRAGMENT_SHADER);
 
     return m_pDescriptorSetLayoutMesh->finalize(m_pDevice);
 }
@@ -276,7 +275,6 @@ bool MeshRenderer::createCommonDescriptorSet()
     }
 
     m_pDescriptorSetCommon->updateUniformBufferDescriptor(SHADER_BINDING::PER_FRAME, m_pPointLightBuffer);
-    m_pDescriptorSetCommon->updateSamplerDescriptor(SHADER_BINDING::SAMPLER_ONE, m_pAniSampler);
     return true;
 }
 
@@ -452,7 +450,7 @@ void MeshRenderer::onMeshAdded(Entity entity)
         // Create per-mesh descriptor set
         meshRenderResources.pDescriptorSet = m_pDevice->allocateDescriptorSet(m_pDescriptorSetLayoutMesh);
         meshRenderResources.pDescriptorSet->updateUniformBufferDescriptor(SHADER_BINDING::MATERIAL_CONSTANTS, meshRenderResources.pMaterialBuffer);
-        meshRenderResources.pDescriptorSet->updateSampledTextureDescriptor(SHADER_BINDING::TEXTURE_ONE, material.textures[0].get());
+        meshRenderResources.pDescriptorSet->updateCombinedTextureSamplerDescriptor(SHADER_BINDING::TEXTURE_ONE, material.textures[0].get(), m_pAniSampler);
 
         modelRenderResources.MeshRenderResources.push_back(meshRenderResources);
     }

--- a/GameProject/Engine/Rendering/ShaderBindings.hpp
+++ b/GameProject/Engine/Rendering/ShaderBindings.hpp
@@ -4,7 +4,6 @@
 
 enum class SHADER_BINDING : uint32_t {
     PER_FRAME           = 0u,
-    SAMPLER_ONE         = 1u,
     PER_OBJECT          = 2u,
     MATERIAL_CONSTANTS  = 3u,
     TEXTURE_ONE         = 4u

--- a/GameProject/Engine/Rendering/Shaders/Mesh_fs.hlsl
+++ b/GameProject/Engine/Rendering/Shaders/Mesh_fs.hlsl
@@ -1,5 +1,5 @@
 Texture2D diffuseTX : register(t4);
-SamplerState sampAni : register(s1);
+SamplerState sampAni : register(s4);
 
 cbuffer material : register(b3) {
     float4 Ks;

--- a/GameProject/Engine/Rendering/Shaders/README.md
+++ b/GameProject/Engine/Rendering/Shaders/README.md
@@ -1,0 +1,24 @@
+## Creating shaders
+Beneath are guidelines for writing shaders and including them into the project.
+
+### File naming conventions
+Shader file names consist of three parts, the name, postfix and file extension.
+* The name part can be whatever
+* The postfix is dependent on the shader stage (the shader stage names are mostly derived from DirectX):
+  * _vs for vertex shaders
+  * _hs for hull shaders
+  * _ds for domain shaders
+  * _gs for geometry shaders
+  * _fs for fragment shaders
+* The file extension is .hlsl for DirectX 11 shaders, and .glsl for Vulkan shaders.
+
+### Binding slots
+In DirectX 11 shaders, samplers should be bound to the same indices as the textures they sample.
+
+The reason for this special rule is that unlike DirectX 11, Vulkan allows samplers and textures to be bound as a single shader resource (combined image-sampler descriptors). Since the graphics API abstraction is favoring Vulkan over DirectX 11, it doesn't acknowledge the concept of textures and samplers being separate. As such, no binding slots are specified for samplers by the API abstraction users. Hence, DirectX shaders should emulate combined image-sampler descriptors using the aforementioned rule.
+
+### Document input layout
+Input layouts need to be specified for each vertex shader in ShaderHandler.cpp.
+
+### Compiling shaders
+DirectX 11 shaders are compiled at run-time. Vulkan shaders need to be compiled from GLSL to SPIR-V (.spv) each time a shader is added or modified. The latter is done by running the script compile-shaders.py in the tools folder. The script looks for each GLSL file in the Shaders folder and compiles them into SPIR-V.

--- a/GameProject/Engine/Rendering/Shaders/UI_fs.glsl
+++ b/GameProject/Engine/Rendering/Shaders/UI_fs.glsl
@@ -1,8 +1,7 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(binding = 4) uniform texture2D u_UITexture;
-layout(binding = 1) uniform sampler u_Sampler;
+layout(binding = 4) uniform sampler2D u_UITexture;
 
 layout (binding = 2) uniform PerObject {
     vec2 Position, Size;

--- a/GameProject/Engine/Rendering/Shaders/UI_fs.glsl
+++ b/GameProject/Engine/Rendering/Shaders/UI_fs.glsl
@@ -1,7 +1,8 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(binding = 4) uniform sampler2D u_UITexture;
+layout(binding = 4) uniform texture2D u_UITexture;
+layout(binding = 1) uniform sampler u_Sampler;
 
 layout (binding = 2) uniform PerObject {
     vec2 Position, Size;

--- a/GameProject/Engine/Rendering/Shaders/UI_fs.hlsl
+++ b/GameProject/Engine/Rendering/Shaders/UI_fs.hlsl
@@ -1,5 +1,5 @@
 Texture2D uiTexture : register(t4);
-SamplerState sampAni : register(s1);
+SamplerState sampAni : register(s4);
 
 cbuffer perObject : register(b2)
 {

--- a/GameProject/Engine/UI/Panel.cpp
+++ b/GameProject/Engine/UI/Panel.cpp
@@ -204,10 +204,11 @@ bool UIHandler::createPipeline()
     pipelineInfo.PrimitiveTopology = PRIMITIVE_TOPOLOGY::TRIANGLE_STRIP;
 
     pipelineInfo.RasterizerStateInfo = {};
-    pipelineInfo.RasterizerStateInfo.PolygonMode          = POLYGON_MODE::FILL;
-    pipelineInfo.RasterizerStateInfo.CullMode             = CULL_MODE::NONE;
-    pipelineInfo.RasterizerStateInfo.FrontFaceOrientation = FRONT_FACE_ORIENTATION::CLOCKWISE;
-    pipelineInfo.RasterizerStateInfo.DepthBiasEnable      = false;
+    pipelineInfo.RasterizerStateInfo.PolygonMode            = POLYGON_MODE::FILL;
+    pipelineInfo.RasterizerStateInfo.CullMode               = CULL_MODE::NONE;
+    pipelineInfo.RasterizerStateInfo.FrontFaceOrientation   = FRONT_FACE_ORIENTATION::CLOCKWISE;
+    pipelineInfo.RasterizerStateInfo.DepthBiasEnable        = false;
+    pipelineInfo.RasterizerStateInfo.LineWidth              = 1.0f;
 
     pipelineInfo.DepthStencilStateInfo = {};
     pipelineInfo.DepthStencilStateInfo.DepthTestEnabled     = true;
@@ -233,7 +234,7 @@ bool UIHandler::createPipeline()
         blendConstant = 1.0f;
     }
 
-    pipelineInfo.DynamicStates  = { PIPELINE_DYNAMIC_STATE::VIEWPORT };
+    pipelineInfo.DynamicStates  = { PIPELINE_DYNAMIC_STATE::VIEWPORT, PIPELINE_DYNAMIC_STATE::SCISSOR };
     pipelineInfo.pLayout        = m_pPipelineLayout;
     pipelineInfo.pRenderPass    = m_pRenderPass;
     pipelineInfo.Subpass        = 0u;

--- a/GameProject/Engine/UI/Panel.cpp
+++ b/GameProject/Engine/UI/Panel.cpp
@@ -183,8 +183,7 @@ bool UIHandler::createDescriptorSetLayout()
     // Create a single layout, even if some descriptors are per-panel and per-texture attachment
     m_pDescriptorSetLayout = m_pDevice->createDescriptorSetLayout();
     m_pDescriptorSetLayout->addBindingUniformBuffer(SHADER_BINDING::PER_OBJECT, SHADER_TYPE::VERTEX_SHADER | SHADER_TYPE::FRAGMENT_SHADER);
-    m_pDescriptorSetLayout->addBindingSampler(SHADER_BINDING::SAMPLER_ONE, SHADER_TYPE::FRAGMENT_SHADER);
-    m_pDescriptorSetLayout->addBindingSampledTexture(SHADER_BINDING::TEXTURE_ONE, SHADER_TYPE::FRAGMENT_SHADER);
+    m_pDescriptorSetLayout->addBindingCombinedTextureSampler(SHADER_BINDING::TEXTURE_ONE, SHADER_TYPE::FRAGMENT_SHADER);
     return m_pDescriptorSetLayout->finalize(m_pDevice);
 }
 
@@ -402,8 +401,7 @@ bool UIHandler::createPanelRenderResources(std::vector<AttachmentRenderResources
         }
 
         pDescriptorSet->updateUniformBufferDescriptor(SHADER_BINDING::PER_OBJECT, pPerAttachmentBuffer);
-        pDescriptorSet->updateSamplerDescriptor(SHADER_BINDING::SAMPLER_ONE, m_pAniSampler);
-        pDescriptorSet->updateSampledTextureDescriptor(SHADER_BINDING::TEXTURE_ONE, attachment.texture.get());
+        pDescriptorSet->updateCombinedTextureSamplerDescriptor(SHADER_BINDING::TEXTURE_ONE, attachment.texture.get(), m_pAniSampler);
 
         renderResources.push_back({pDescriptorSet, pPerAttachmentBuffer});
     }

--- a/GameProject/Engine/UI/UIRenderer.cpp
+++ b/GameProject/Engine/UI/UIRenderer.cpp
@@ -12,9 +12,7 @@ UIRenderer::UIRenderer(ECSCore* pECS, Device* pDevice)
     m_pRenderTarget(pDevice->getBackBuffer()),
     m_pDepthStencil(pDevice->getDepthStencil()),
     m_pQuad(nullptr),
-    m_pDescriptorSetLayoutCommon(nullptr),
-    m_pDescriptorSetLayoutPanel(nullptr),
-    m_pDescriptorSetCommon(nullptr),
+    m_pDescriptorSetLayout(nullptr),
     m_pAniSampler(nullptr),
     m_pRenderPass(nullptr),
     m_pFramebuffer(nullptr),
@@ -39,9 +37,7 @@ UIRenderer::~UIRenderer()
 
     delete m_pCommandList;
     delete m_pCommandPool;
-    delete m_pDescriptorSetCommon;
-    delete m_pDescriptorSetLayoutCommon;
-    delete m_pDescriptorSetLayoutPanel;
+    delete m_pDescriptorSetLayout;
     delete m_pRenderPass;
     delete m_pFramebuffer;
     delete m_pPipelineLayout;
@@ -70,10 +66,6 @@ bool UIRenderer::init()
     m_pAniSampler   = pShaderResourceHandler->getAniSampler();
 
     if (!createDescriptorSetLayouts()) {
-        return false;
-    }
-
-    if (!createCommonDescriptorSet()) {
         return false;
     }
 
@@ -127,8 +119,6 @@ void UIRenderer::recordCommands()
     m_pCommandList->bindPipeline(m_pPipeline);
     m_pCommandList->bindVertexBuffer(0, m_pQuad);
 
-    m_pCommandList->bindDescriptorSet(m_pDescriptorSetCommon);
-
     for (const PanelRenderResources& panelRenderResources : m_PanelRenderResources.getVec()) {
         m_pCommandList->bindDescriptorSet(panelRenderResources.pDescriptorSet);
         m_pCommandList->draw(4);
@@ -145,35 +135,14 @@ void UIRenderer::executeCommands()
 
 bool UIRenderer::createDescriptorSetLayouts()
 {
-    m_pDescriptorSetLayoutCommon = m_pDevice->createDescriptorSetLayout();
-    if (!m_pDescriptorSetLayoutCommon) {
+    m_pDescriptorSetLayout = m_pDevice->createDescriptorSetLayout();
+    if (!m_pDescriptorSetLayout) {
         return false;
     }
 
-    m_pDescriptorSetLayoutCommon->addBindingSampler(SHADER_BINDING::SAMPLER_ONE, SHADER_TYPE::FRAGMENT_SHADER);
-    if (!m_pDescriptorSetLayoutCommon->finalize(m_pDevice)) {
-        return false;
-    }
-
-    m_pDescriptorSetLayoutPanel = m_pDevice->createDescriptorSetLayout();
-    if (!m_pDescriptorSetLayoutPanel) {
-        return false;
-    }
-
-    m_pDescriptorSetLayoutPanel->addBindingUniformBuffer(SHADER_BINDING::PER_OBJECT, SHADER_TYPE::VERTEX_SHADER | SHADER_TYPE::FRAGMENT_SHADER);
-    m_pDescriptorSetLayoutPanel->addBindingSampledTexture(SHADER_BINDING::TEXTURE_ONE, SHADER_TYPE::FRAGMENT_SHADER);
-    return m_pDescriptorSetLayoutPanel->finalize(m_pDevice);
-}
-
-bool UIRenderer::createCommonDescriptorSet()
-{
-    m_pDescriptorSetCommon = m_pDevice->allocateDescriptorSet(m_pDescriptorSetLayoutCommon);
-    if (!m_pDescriptorSetCommon) {
-        return false;
-    }
-
-    m_pDescriptorSetCommon->updateSamplerDescriptor(SHADER_BINDING::SAMPLER_ONE, m_pAniSampler);
-    return true;
+    m_pDescriptorSetLayout->addBindingUniformBuffer(SHADER_BINDING::PER_OBJECT, SHADER_TYPE::VERTEX_SHADER | SHADER_TYPE::FRAGMENT_SHADER);
+    m_pDescriptorSetLayout->addBindingCombinedTextureSampler(SHADER_BINDING::TEXTURE_ONE, SHADER_TYPE::FRAGMENT_SHADER);
+    return m_pDescriptorSetLayout->finalize(m_pDevice);
 }
 
 bool UIRenderer::createRenderPass()
@@ -246,7 +215,7 @@ bool UIRenderer::createFramebuffer()
 
 bool UIRenderer::createPipeline()
 {
-    m_pPipelineLayout = m_pDevice->createPipelineLayout({ m_pDescriptorSetLayoutCommon, m_pDescriptorSetLayoutPanel });
+    m_pPipelineLayout = m_pDevice->createPipelineLayout({ m_pDescriptorSetLayout });
     if (!m_pPipelineLayout) {
         return false;
     }
@@ -334,13 +303,13 @@ void UIRenderer::onPanelAdded(Entity entity)
     }
 
     // Create descriptor set
-    panelRenderResources.pDescriptorSet = m_pDevice->allocateDescriptorSet(m_pDescriptorSetLayoutPanel);
+    panelRenderResources.pDescriptorSet = m_pDevice->allocateDescriptorSet(m_pDescriptorSetLayout);
     if (!panelRenderResources.pDescriptorSet) {
         return;
     }
 
     panelRenderResources.pDescriptorSet->updateUniformBufferDescriptor(SHADER_BINDING::PER_OBJECT, panelRenderResources.pBuffer);
-    panelRenderResources.pDescriptorSet->updateSampledTextureDescriptor(SHADER_BINDING::TEXTURE_ONE, panel.texture);
+    panelRenderResources.pDescriptorSet->updateCombinedTextureSamplerDescriptor(SHADER_BINDING::TEXTURE_ONE, panel.texture, m_pAniSampler);
 
     m_PanelRenderResources.push_back(panelRenderResources, entity);
 }

--- a/GameProject/Engine/UI/UIRenderer.cpp
+++ b/GameProject/Engine/UI/UIRenderer.cpp
@@ -271,10 +271,11 @@ bool UIRenderer::createPipeline()
     pipelineInfo.Viewports = { viewport };
 
     pipelineInfo.RasterizerStateInfo = {};
-    pipelineInfo.RasterizerStateInfo.PolygonMode          = POLYGON_MODE::FILL;
-    pipelineInfo.RasterizerStateInfo.CullMode             = CULL_MODE::NONE;
-    pipelineInfo.RasterizerStateInfo.FrontFaceOrientation = FRONT_FACE_ORIENTATION::CLOCKWISE;
-    pipelineInfo.RasterizerStateInfo.DepthBiasEnable      = false;
+    pipelineInfo.RasterizerStateInfo.PolygonMode            = POLYGON_MODE::FILL;
+    pipelineInfo.RasterizerStateInfo.CullMode               = CULL_MODE::NONE;
+    pipelineInfo.RasterizerStateInfo.FrontFaceOrientation   = FRONT_FACE_ORIENTATION::CLOCKWISE;
+    pipelineInfo.RasterizerStateInfo.DepthBiasEnable        = false;
+    pipelineInfo.RasterizerStateInfo.LineWidth              = 1.0f;
 
     pipelineInfo.DepthStencilStateInfo = {};
     pipelineInfo.DepthStencilStateInfo.DepthTestEnabled     = true;
@@ -300,6 +301,7 @@ bool UIRenderer::createPipeline()
         blendConstant = 1.0f;
     }
 
+    pipelineInfo.DynamicStates  = { PIPELINE_DYNAMIC_STATE::SCISSOR };
     pipelineInfo.pLayout        = m_pPipelineLayout;
     pipelineInfo.pRenderPass    = m_pRenderPass;
     pipelineInfo.Subpass        = 0u;

--- a/GameProject/Engine/UI/UIRenderer.hpp
+++ b/GameProject/Engine/UI/UIRenderer.hpp
@@ -26,7 +26,6 @@ public:
 
 private:
     bool createDescriptorSetLayouts();
-    bool createCommonDescriptorSet();
     bool createRenderPass();
     bool createFramebuffer();
     bool createPipeline();
@@ -52,9 +51,7 @@ private:
     IRenderPass* m_pRenderPass;
     IFramebuffer* m_pFramebuffer;
 
-    IDescriptorSetLayout* m_pDescriptorSetLayoutCommon; // Common for all panels: Sampler
-    IDescriptorSetLayout* m_pDescriptorSetLayoutPanel;  // Per panel: Buffer containing transform and highlight settings, texture
-    DescriptorSet* m_pDescriptorSetCommon;
+    IDescriptorSetLayout* m_pDescriptorSetLayout;
 
     Viewport m_Viewport;
 


### PR DESCRIPTION
Fixes:
* An sType member was missing when creating descriptor set layouts
* Pipeline creation crashing for various reasons
* GLSL shaders were using incorrect binding slots

Also, separate shaders and textures no longer exist in the graphics API abstraction, only combined texture-sampler descriptors are acknowledged. DirectX shaders need to have one bound sampler for each texture to emulate combined texture-sampler bindings.