### PR TITLE
Acquire and wait for available backbuffer

### DIFF
--- a/src/Engine/IGame.cpp
+++ b/src/Engine/IGame.cpp
@@ -42,7 +42,7 @@ bool IGame::init()
     DescriptorCounts descriptorPoolSize;
     descriptorPoolSize.setAll(100u);
 
-    m_pDevice = Device::create(RENDERING_API::VULKAN, swapChainInfo, &m_Window);
+    m_pDevice = Device::create(RENDERING_API::DIRECTX11, swapChainInfo, &m_Window);
     if (!m_pDevice || !m_pDevice->init(descriptorPoolSize)) {
         return false;
     }

--- a/src/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.cpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.cpp
@@ -75,6 +75,12 @@ void CommandListDX11::beginRenderPass(IRenderPass* pRenderPass, const RenderPass
     pRenderPassDX->begin(beginInfo, m_pContext);
 }
 
+void CommandListDX11::endRenderPass(IRenderPass* pRenderPass)
+{
+    // Unbind any render targets
+    m_pContext->OMSetRenderTargets(0u, nullptr, nullptr);
+}
+
 void CommandListDX11::bindPipeline(IPipeline* pPipeline)
 {
     PipelineDX11* pPipelineDX = reinterpret_cast<PipelineDX11*>(pPipeline);

--- a/src/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp
@@ -24,6 +24,7 @@ public:
     bool end() override final;
 
     void beginRenderPass(IRenderPass* pRenderPass, const RenderPassBeginInfo& beginInfo) override final;
+    void endRenderPass(IRenderPass* pRenderPass) override final;
     void bindPipeline(IPipeline* pPipeline) override final;
 
     // Shader resources

--- a/src/Engine/Rendering/APIAbstractions/DX11/DeviceCreatorDX11.cpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/DeviceCreatorDX11.cpp
@@ -26,7 +26,12 @@ Device* DeviceCreatorDX11::createDevice(const SwapchainInfo& swapChainInfo, cons
 
 Swapchain* DeviceCreatorDX11::createSwapchain(Device* pDevice)
 {
-    return DBG_NEW SwapchainDX11(m_pSwapChain, m_pBackbuffer, m_ppDepthTextures);
+    SwapchainInfoDX11 swapchainInfo = {};
+    swapchainInfo.pSwapchain        = m_pSwapChain;
+    swapchainInfo.pBackbuffer       = m_pBackbuffer;
+    swapchainInfo.ppDepthTextures   = m_ppDepthTextures;
+
+    return SwapchainDX11::create(swapchainInfo, reinterpret_cast<DeviceDX11*>(pDevice));
 }
 
 bool DeviceCreatorDX11::initDeviceAndSwapChain(const SwapchainInfo& swapChainInfo, const Window* pWindow)

--- a/src/Engine/Rendering/APIAbstractions/DX11/SwapchainDX11.cpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/SwapchainDX11.cpp
@@ -2,18 +2,40 @@
 
 #include <Engine/Utils/DirectXUtils.hpp>
 
-SwapchainDX11::SwapchainDX11(IDXGISwapChain* pSwapchain, Texture* pBackbuffer, const Texture* const * ppDepthTextures)
-    :Swapchain(ppDepthTextures),
-    m_pSwapchain(pSwapchain),
-    m_pBackbuffer(reinterpret_cast<TextureDX11*>(pBackbuffer))
+SwapchainDX11* SwapchainDX11::create(const SwapchainInfoDX11& swapchainInfo, DeviceDX11* pDevice)
 {
-    std::memcpy(m_ppDepthTextures, ppDepthTextures, sizeof(Texture*) * MAX_FRAMES_IN_FLIGHT);
+    ISemaphore* ppSemaphores[MAX_FRAMES_IN_FLIGHT];
+    for (uint32_t frameIndex = 0u; frameIndex < MAX_FRAMES_IN_FLIGHT; frameIndex += 1u) {
+        ppSemaphores[frameIndex] = pDevice->createSemaphore();
+        if (!ppSemaphores[frameIndex]) {
+            return nullptr;
+        }
+    }
+
+    IFence* pFence = pDevice->createFence(true);
+    if (!pFence) {
+        return nullptr;
+    }
+
+    return DBG_NEW SwapchainDX11(swapchainInfo, ppSemaphores, pFence);
 }
+
+SwapchainDX11::SwapchainDX11(const SwapchainInfoDX11& swapchainInfo, const ISemaphore* const * ppSemaphores, IFence* pFence)
+    :Swapchain(swapchainInfo.ppDepthTextures, ppSemaphores, pFence),
+    m_pSwapchain(swapchainInfo.pSwapchain),
+    m_pBackbuffer(reinterpret_cast<TextureDX11*>(swapchainInfo.pBackbuffer))
+{}
 
 SwapchainDX11::~SwapchainDX11()
 {
     SAFERELEASE(m_pSwapchain)
     delete m_pBackbuffer;
+}
+
+bool SwapchainDX11::acquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions)
+{
+    frameIndex = (frameIndex + 1u) % MAX_FRAMES_IN_FLIGHT;
+    return true;
 }
 
 void SwapchainDX11::present(ISemaphore** ppWaitSemaphores, uint32_t waitSemaphoreCount)

--- a/src/Engine/Rendering/APIAbstractions/DX11/SwapchainDX11.hpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/SwapchainDX11.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Engine/Rendering/APIAbstractions/Device.hpp>
+#include <Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp>
 #include <Engine/Rendering/APIAbstractions/DX11/TextureDX11.hpp>
 #include <Engine/Rendering/APIAbstractions/Swapchain.hpp>
 
@@ -9,12 +9,22 @@
 
 class TextureDX11;
 
+struct SwapchainInfoDX11 {
+    IDXGISwapChain* pSwapchain;
+    Texture* pBackbuffer;
+    const Texture* const * ppDepthTextures;
+};
+
 class SwapchainDX11 : public Swapchain
 {
 public:
-    SwapchainDX11(IDXGISwapChain* pSwapchain, Texture* pBackbuffer, const Texture* const * ppDepthTextures);
+    static SwapchainDX11* create(const SwapchainInfoDX11& swapchainInfo, DeviceDX11* pDevice);
+
+public:
+    SwapchainDX11(const SwapchainInfoDX11& swapchainInfo, const ISemaphore* const * ppSemaphores, IFence* pFence);
     ~SwapchainDX11();
 
+    bool acquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions) override final;
     void present(ISemaphore** ppWaitSemaphores, uint32_t waitSemaphoreCount) override final;
 
     Texture* getBackbuffer(uint32_t frameIndex) override final { return m_pBackbuffer; }

--- a/src/Engine/Rendering/APIAbstractions/Device.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Device.hpp
@@ -121,11 +121,12 @@ public:
     // waitAll: Wait for every fence or just one. timeout: Nanoseconds
     virtual bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) = 0;
 
+    Swapchain* getSwapchain()                               { return m_pSwapchain; }
     Texture* getBackbuffer(uint32_t frameIndex)             { return m_pSwapchain->getBackbuffer(frameIndex); }
     Texture* getDepthStencil(uint32_t frameIndex)           { return m_pSwapchain->getDepthTexture(frameIndex); }
     ShaderHandler* getShaderHandler()                       { return m_pShaderHandler; }
     const QueueFamilyIndices& getQueueFamilyIndices() const { return m_QueueFamilyIndices; }
-    inline uint32_t getFrameIndex() const { return m_FrameIndex; }
+    inline uint32_t& getFrameIndex()                        { return m_FrameIndex; }
 
 protected:
     friend DescriptorPoolHandler;

--- a/src/Engine/Rendering/APIAbstractions/ICommandList.hpp
+++ b/src/Engine/Rendering/APIAbstractions/ICommandList.hpp
@@ -42,6 +42,7 @@ public:
     virtual bool end() = 0;
 
     virtual void beginRenderPass(IRenderPass* pRenderPass, const RenderPassBeginInfo& beginInfo) = 0;
+    virtual void endRenderPass(IRenderPass* pRenderPass) = 0;
     virtual void bindPipeline(IPipeline* pPipeline) = 0;
 
     // Shader resources

--- a/src/Engine/Rendering/APIAbstractions/Swapchain.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Swapchain.cpp
@@ -1,13 +1,18 @@
 #include "Swapchain.hpp"
 
-Swapchain::Swapchain(const Texture* const * ppDepthTextures)
+Swapchain::Swapchain(const Texture* const * ppDepthTextures, const ISemaphore* const * ppSemaphores, IFence* pFence)
+    :m_pFence(pFence)
 {
     std::memcpy(m_ppDepthTextures, ppDepthTextures, sizeof(Texture*) * MAX_FRAMES_IN_FLIGHT);
+    std::memcpy(m_ppSemaphores, ppSemaphores, sizeof(ISemaphore*) * MAX_FRAMES_IN_FLIGHT);
 }
 
 Swapchain::~Swapchain()
 {
-    for (uint32_t depthTxIdx = 0u; depthTxIdx < MAX_FRAMES_IN_FLIGHT; depthTxIdx += 1u) {
-        delete m_ppDepthTextures[depthTxIdx];
+    for (uint32_t frameIndex = 0u; frameIndex < MAX_FRAMES_IN_FLIGHT; frameIndex += 1u) {
+        delete m_ppDepthTextures[frameIndex];
+        delete m_ppSemaphores[frameIndex];
     }
+
+    delete m_pFence;
 }

--- a/src/Engine/Rendering/APIAbstractions/Swapchain.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Swapchain.hpp
@@ -2,20 +2,35 @@
 
 #include <Engine/Rendering/APIAbstractions/GeneralResources.hpp>
 
+class IFence;
 class ISemaphore;
 class Texture;
+
+enum class SYNC_OPTION {
+    FENCE       = 1,
+    SEMAPHORE   = FENCE << 1
+};
+
+DEFINE_BITMASK_OPERATIONS(SYNC_OPTION)
 
 class Swapchain
 {
 public:
-    Swapchain(const Texture* const * ppDepthTextures);
+    Swapchain(const Texture* const * ppDepthTextures, const ISemaphore* const * ppSemaphores, IFence* pFence);
     virtual ~Swapchain();
 
+    // Specifying fence as a sync option does not mean the CPU will block inside this function. The fence needs to be retrieved
+    // and waited for separately.
+    virtual bool acquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions) = 0;
     virtual void present(ISemaphore** ppWaitSemaphores, uint32_t waitSemaphoreCount) = 0;
 
     virtual Texture* getBackbuffer(uint32_t frameIndex) = 0;
-    inline Texture* getDepthTexture(uint32_t frameIndex) { return m_ppDepthTextures[frameIndex]; }
+    inline Texture* getDepthTexture(uint32_t frameIndex)    { return m_ppDepthTextures[frameIndex]; }
+    inline ISemaphore* getSemaphore(uint32_t frameIndex)    { return m_ppSemaphores[frameIndex]; }
+    inline IFence* getFence()                               { return m_pFence; }
 
 protected:
     Texture* m_ppDepthTextures[MAX_FRAMES_IN_FLIGHT];
+    ISemaphore* m_ppSemaphores[MAX_FRAMES_IN_FLIGHT];
+    IFence* m_pFence;
 };

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp
@@ -12,9 +12,10 @@ public:
 
     bool begin(COMMAND_LIST_USAGE usageFlags, CommandListBeginInfo* pBeginInfo) override final;
     bool reset() override final;
-    inline bool end() override final { return vkEndCommandBuffer(m_CommandBuffer) == VK_SUCCESS; }
+    bool end() override final { return vkEndCommandBuffer(m_CommandBuffer) == VK_SUCCESS; }
 
     void beginRenderPass(IRenderPass* pRenderPass, const RenderPassBeginInfo& beginInfo) override final {};
+    void endRenderPass(IRenderPass* pRenderPass) override final {};
     void bindPipeline(IPipeline* pPipeline) override final {};
 
     // Shader resources

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/DeviceCreatorVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/DeviceCreatorVK.cpp
@@ -77,7 +77,13 @@ Swapchain* DeviceCreatorVK::createSwapchain(Device* pDevice)
         return nullptr;
     }
 
-    return DBG_NEW SwapchainVK(m_Swapchain, m_ppBackbuffers, m_ppDepthTextures, pDeviceVK);
+    SwapchainInfoVK swapchainInfo = {};
+    swapchainInfo.Swapchain         = m_Swapchain;
+    swapchainInfo.ppBackbuffers     = m_ppBackbuffers;
+    swapchainInfo.ppDepthTextures   = m_ppDepthTextures;
+    swapchainInfo.pDevice           = pDeviceVK;
+
+    return SwapchainVK::create(swapchainInfo);
 }
 
 bool DeviceCreatorVK::initInstance(const Window* pWindow, bool debugMode)

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/FenceVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/FenceVK.cpp
@@ -6,7 +6,7 @@ FenceVK* FenceVK::create(bool createSignaled, DeviceVK* pDevice)
 {
     VkFenceCreateInfo fenceInfo = {};
     fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-    fenceInfo.flags = createSignaled ? VK_FENCE_CREATE_FLAG_BITS_MAX_ENUM : 0u;
+    fenceInfo.flags = createSignaled ? VK_FENCE_CREATE_SIGNALED_BIT : 0u;
 
     VkFence fence = VK_NULL_HANDLE;
     if (vkCreateFence(pDevice->getDevice(), &fenceInfo, nullptr, &fence) != VK_SUCCESS) {
@@ -31,3 +31,13 @@ bool FenceVK::isSignaled()
 {
     return vkGetFenceStatus(m_pDevice->getDevice(), m_Fence) == VK_SUCCESS;
 };
+
+bool FenceVK::reset()
+{
+    if (vkResetFences(m_pDevice->getDevice(), 1u, &m_Fence) != VK_SUCCESS) {
+        LOG_WARNING("Failed to reset fence");
+        return false;
+    }
+
+    return true;
+}

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/FenceVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/FenceVK.hpp
@@ -15,6 +15,8 @@ public:
 
     bool isSignaled() override final;
 
+    bool reset();
+
     inline VkFence getFence() { return m_Fence; }
 
 private:

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/SemaphoreVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/SemaphoreVK.cpp
@@ -5,7 +5,7 @@
 SemaphoreVK* SemaphoreVK::create(DeviceVK* pDevice)
 {
     VkSemaphoreCreateInfo semaphoreInfo = {};
-    semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
+    semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
 
     VkSemaphore semaphore = VK_NULL_HANDLE;
     if (vkCreateSemaphore(pDevice->getDevice(), &semaphoreInfo, nullptr, &semaphore) != VK_SUCCESS) {

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/SwapchainVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/SwapchainVK.hpp
@@ -3,17 +3,29 @@
 #include <Engine/Rendering/APIAbstractions/Device.hpp>
 #include <Engine/Rendering/APIAbstractions/Swapchain.hpp>
 #include <Engine/Rendering/APIAbstractions/Vulkan/TextureVK.hpp>
+#include <Engine/Utils/EnumClass.hpp>
 
 #include <vulkan/vulkan.h>
 
 class DeviceVK;
 
+struct SwapchainInfoVK {
+    VkSwapchainKHR Swapchain;
+    const Texture* const * ppBackbuffers;
+    const Texture* const * ppDepthTextures;
+    DeviceVK* pDevice;
+};
+
 class SwapchainVK : public Swapchain
 {
 public:
-    SwapchainVK(VkSwapchainKHR swapchain, const Texture* const * ppBackbuffers, const Texture* const * ppDepthTextures, DeviceVK* pDevice);
+    static SwapchainVK* create(const SwapchainInfoVK& swapchainInfo);
+
+public:
+    SwapchainVK(const SwapchainInfoVK& swapchainInfo, const ISemaphore* const * ppSemaphores, IFence* pFence);
     ~SwapchainVK();
 
+    bool acquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions) override final;
     void present(ISemaphore** ppWaitSemaphores, uint32_t waitSemaphoreCount) override final;
 
     Texture* getBackbuffer(uint32_t frameIndex) override final { return m_ppBackbuffers[frameIndex]; }

--- a/src/Engine/Rendering/MeshRenderer.cpp
+++ b/src/Engine/Rendering/MeshRenderer.cpp
@@ -192,7 +192,6 @@ void MeshRenderer::recordCommands()
     }
 
     pCommandList->bindPipeline(m_pPipeline);
-
     pCommandList->bindDescriptorSet(m_pDescriptorSetCommon);
 
     for (Entity renderableID : m_Renderables.getIDs()) {
@@ -222,6 +221,7 @@ void MeshRenderer::recordCommands()
         }
     }
 
+    pCommandList->endRenderPass(m_pRenderPass);
     pCommandList->end();
 }
 

--- a/src/Engine/Rendering/RenderingHandler.cpp
+++ b/src/Engine/Rendering/RenderingHandler.cpp
@@ -28,11 +28,18 @@ bool RenderingHandler::init()
 
 void RenderingHandler::render()
 {
+    Swapchain* pSwapchain = m_pDevice->getSwapchain();
+    uint32_t& frameIndex = m_pDevice->getFrameIndex();
+    pSwapchain->acquireNextBackbuffer(frameIndex, SYNC_OPTION::FENCE);
+
+    IFence* pBackbufferReadyFence = pSwapchain->getFence();
+    m_pDevice->waitForFences(&pBackbufferReadyFence, 1u, false, UINT64_MAX);
+
     updateBuffers();
     recordCommandBuffers();
     executeCommandBuffers();
 
-    m_pDevice->presentBackbuffer(nullptr, 0u);
+    pSwapchain->present(nullptr, 0u);
 }
 
 void RenderingHandler::updateBuffers()

--- a/src/Engine/UI/Panel.cpp
+++ b/src/Engine/UI/Panel.cpp
@@ -349,6 +349,7 @@ void UIHandler::renderTexturesOntoPanel(std::vector<TextureAttachment>& attachme
         m_pCommandList->draw(4u);
     }
 
+    m_pCommandList->endRenderPass(m_pRenderPass);
     m_pCommandList->end();
     SemaphoreSubmitInfo semaphoreInfo = {};
     m_pDevice->graphicsQueueSubmit(m_pCommandList, nullptr, semaphoreInfo);

--- a/src/Engine/UI/UIRenderer.cpp
+++ b/src/Engine/UI/UIRenderer.cpp
@@ -133,6 +133,7 @@ void UIRenderer::recordCommands()
         pCommandList->draw(4);
     }
 
+    pCommandList->endRenderPass(m_pRenderPass);
     pCommandList->end();
 }
 


### PR DESCRIPTION
The swapchain now has a fence and one semaphore per frame. At least one of these must be used to wait for an available backbuffer at the beginning of each frame. Currently, the fence is used.