### PR TITLE
Call 2ndary cmd buffers using primary, move render pass creation to rendering handler

### DIFF
--- a/src/Engine/ECS/Renderer.cpp
+++ b/src/Engine/ECS/Renderer.cpp
@@ -5,9 +5,10 @@
 #include <Engine/Utils/DirectXUtils.hpp>
 #include <Engine/Utils/Logger.hpp>
 
-Renderer::Renderer(ECSCore* pECS, Device* pDevice)
+Renderer::Renderer(ECSCore* pECS, Device* pDevice, RenderingHandler* pRenderingHandler)
     :m_pECS(pECS),
-    m_pDevice(pDevice)
+    m_pDevice(pDevice),
+    m_pRenderingHandler(pRenderingHandler)
 {}
 
 Renderer::~Renderer()

--- a/src/Engine/ECS/Renderer.hpp
+++ b/src/Engine/ECS/Renderer.hpp
@@ -8,6 +8,7 @@ class ComponentHandler;
 class Device;
 class ECSCore;
 class Renderer;
+class RenderingHandler;
 
 struct RendererRegistration {
     ComponentSubscriberRegistration SubscriberRegistration;
@@ -17,14 +18,14 @@ struct RendererRegistration {
 class Renderer
 {
 public:
-    Renderer(ECSCore* pECS, Device* pDevice);
+    Renderer(ECSCore* pECS, Device* pDevice, RenderingHandler* pRenderingHandler);
     ~Renderer();
 
     virtual bool init() = 0;
 
     virtual void updateBuffers() = 0;
     virtual void recordCommands() = 0;
-    virtual void executeCommands() = 0;
+    virtual void executeCommands(ICommandList* pPrimaryCommandList) = 0;
 
     void setComponentSubscriptionID(size_t ID) { m_ComponentSubscriptionID = ID; }
 
@@ -34,6 +35,7 @@ protected:
 
 protected:
     Device* m_pDevice;
+    RenderingHandler* m_pRenderingHandler;
 
 private:
     ECSCore* m_pECS;

--- a/src/Engine/IGame.cpp
+++ b/src/Engine/IGame.cpp
@@ -42,7 +42,7 @@ bool IGame::init()
     DescriptorCounts descriptorPoolSize;
     descriptorPoolSize.setAll(100u);
 
-    m_pDevice = Device::create(RENDERING_API::VULKAN, swapChainInfo, &m_Window);
+    m_pDevice = Device::create(RENDERING_API::DIRECTX11, swapChainInfo, &m_Window);
     if (!m_pDevice || !m_pDevice->init(descriptorPoolSize)) {
         return false;
     }
@@ -54,13 +54,12 @@ bool IGame::init()
     m_pAudioCore        = DBG_NEW AudioCore(&m_ECS);
 
     m_pRenderingHandler = DBG_NEW RenderingHandler(&m_ECS, m_pDevice);
-
-    m_ECS.performRegistrations();
-    m_Window.show();
-
     if (!m_pRenderingHandler->init()) {
         return false;
     }
+
+    m_ECS.performRegistrations();
+    m_Window.show();
 
     return true;
 }

--- a/src/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp
@@ -23,7 +23,10 @@ public:
     bool reset() override final;
     bool end() override final;
 
+    void executeSecondaryCommandList(ICommandList* pSecondaryCommandList) override final;
+
     void beginRenderPass(IRenderPass* pRenderPass, const RenderPassBeginInfo& beginInfo) override final;
+    void nextSubpass(COMMAND_LIST_LEVEL subpassCommandListLevel) override final {};
     void endRenderPass() override final;
     void bindPipeline(IPipeline* pPipeline) override final;
 

--- a/src/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.cpp
@@ -29,17 +29,17 @@ DeviceDX11::~DeviceDX11()
     SAFERELEASE(m_pDevice)
 }
 
-bool DeviceDX11::graphicsQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo)
+bool DeviceDX11::graphicsQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo)
 {
     return executeCommandList(pCommandList);
 }
 
-bool DeviceDX11::transferQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo)
+bool DeviceDX11::transferQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo)
 {
     return executeCommandList(pCommandList);
 }
 
-bool DeviceDX11::computeQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo)
+bool DeviceDX11::computeQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo)
 {
     return executeCommandList(pCommandList);
 }

--- a/src/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
@@ -32,9 +32,9 @@ public:
     DeviceDX11(const DeviceInfoDX11& deviceInfo);
     ~DeviceDX11();
 
-    bool graphicsQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo) override final;
-    bool transferQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo) override final;
-    bool computeQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo) override final;
+    bool graphicsQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo) override final;
+    bool transferQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo) override final;
+    bool computeQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo) override final;
 
     ICommandPool* createCommandPool(COMMAND_POOL_FLAG creationFlags, uint32_t queueFamilyIndex) override final;
 

--- a/src/Engine/Rendering/APIAbstractions/DX11/FenceDX11.hpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/FenceDX11.hpp
@@ -7,4 +7,6 @@ public:
     ~FenceDX11() = default;
 
     bool isSignaled() override final { return true; }
+
+    bool reset() override final { return true; }
 };

--- a/src/Engine/Rendering/APIAbstractions/Device.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Device.hpp
@@ -59,10 +59,10 @@ struct QueueFamilyIndices {
 
 struct SemaphoreSubmitInfo {
     ISemaphore** ppWaitSemaphores;
-    uint32_t waitSemaphoreCount;
+    uint32_t WaitSemaphoreCount;
     PIPELINE_STAGE* pWaitStageFlags;
     ISemaphore** ppSignalSemaphores;
-    uint32_t signalSemaphoreCount;
+    uint32_t SignalSemaphoreCount;
 };
 
 class Device
@@ -76,9 +76,9 @@ public:
 
     bool init(const DescriptorCounts& descriptorCounts);
 
-    virtual bool graphicsQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo) = 0;
-    virtual bool transferQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo) = 0;
-    virtual bool computeQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo) = 0;
+    virtual bool graphicsQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo) = 0;
+    virtual bool transferQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo) = 0;
+    virtual bool computeQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo) = 0;
 
     void presentBackbuffer(ISemaphore** ppWaitSemaphores, uint32_t waitSemaphoreCount);
 

--- a/src/Engine/Rendering/APIAbstractions/Fence.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Fence.hpp
@@ -6,4 +6,6 @@ public:
     virtual ~IFence() = 0 {};
 
     virtual bool isSignaled() = 0;
+
+    virtual bool reset() = 0;
 };

--- a/src/Engine/Rendering/APIAbstractions/ICommandList.hpp
+++ b/src/Engine/Rendering/APIAbstractions/ICommandList.hpp
@@ -41,7 +41,10 @@ public:
     virtual bool reset() = 0;
     virtual bool end() = 0;
 
+    virtual void executeSecondaryCommandList(ICommandList* pSecondaryCommandList) = 0;
+
     virtual void beginRenderPass(IRenderPass* pRenderPass, const RenderPassBeginInfo& beginInfo) = 0;
+    virtual void nextSubpass(COMMAND_LIST_LEVEL subpassCommandListLevel) = 0;
     virtual void endRenderPass() = 0;
     virtual void bindPipeline(IPipeline* pPipeline) = 0;
 

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp
@@ -14,7 +14,10 @@ public:
     bool reset() override final;
     bool end() override final { return vkEndCommandBuffer(m_CommandBuffer) == VK_SUCCESS; }
 
+    void executeSecondaryCommandList(ICommandList* pSecondaryCommandList) override final;
+
     void beginRenderPass(IRenderPass* pRenderPass, const RenderPassBeginInfo& beginInfo) override final;
+    void nextSubpass(COMMAND_LIST_LEVEL subpassCommandListLevel) override final;
     void endRenderPass() override final;
     void bindPipeline(IPipeline* pPipeline) override final;
 

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
@@ -36,9 +36,9 @@ public:
     DeviceVK(const DeviceInfoVK& deviceInfo);
     ~DeviceVK();
 
-    bool graphicsQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo) override final;
-    bool transferQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo) override final;
-    bool computeQueueSubmit(ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo) override final;
+    bool graphicsQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo) override final;
+    bool transferQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo) override final;
+    bool computeQueueSubmit(ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo) override final;
 
     ICommandPool* createCommandPool(COMMAND_POOL_FLAG creationFlags, uint32_t queueFamilyIndex) override final;
 
@@ -82,7 +82,7 @@ private:
 
 private:
     Shader* compileShader(SHADER_TYPE shaderType, const std::string& filePath, const InputLayoutInfo* pInputLayoutInfo) override final;
-    bool executeCommandBuffer(VkQueue queue, ICommandList* pCommandList, IFence* pFence, SemaphoreSubmitInfo& semaphoreSubmitInfo);
+    bool executeCommandBuffer(VkQueue queue, ICommandList* pCommandList, IFence* pFence, const SemaphoreSubmitInfo* pSemaphoreInfo);
 
 private:
     VkInstance m_Instance;

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/FenceVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/FenceVK.hpp
@@ -15,7 +15,7 @@ public:
 
     bool isSignaled() override final;
 
-    bool reset();
+    bool reset() override final;
 
     inline VkFence getFence() { return m_Fence; }
 

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.cpp
@@ -199,8 +199,7 @@ bool TextureVK::submitTempCommandList(CommandListVK* pCommandList, PooledResourc
         return false;
     }
 
-    SemaphoreSubmitInfo semaphoreInfo = {};
-    if (!pDevice->graphicsQueueSubmit(pCommandList, pFence, semaphoreInfo)) {
+    if (!pDevice->graphicsQueueSubmit(pCommandList, pFence, nullptr)) {
         return false;
     }
 

--- a/src/Engine/Rendering/MeshRenderer.cpp
+++ b/src/Engine/Rendering/MeshRenderer.cpp
@@ -5,14 +5,15 @@
 #include <Engine/Rendering/AssetLoaders/ModelLoader.hpp>
 #include <Engine/Rendering/Components/ComponentGroups.hpp>
 #include <Engine/Rendering/Components/VPMatrices.hpp>
+#include <Engine/Rendering/RenderingHandler.hpp>
 #include <Engine/Rendering/ShaderBindings.hpp>
 #include <Engine/Rendering/ShaderResourceHandler.hpp>
 #include <Engine/Transform.hpp>
 
 #include <algorithm>
 
-MeshRenderer::MeshRenderer(ECSCore* pECS, Device* pDevice)
-    :Renderer(pECS, pDevice),
+MeshRenderer::MeshRenderer(ECSCore* pECS, Device* pDevice, RenderingHandler* pRenderingHandler)
+    :Renderer(pECS, pDevice, pRenderingHandler),
     m_pDevice(pDevice),
     m_pModelLoader(nullptr),
     m_pTransformHandler(nullptr),
@@ -23,13 +24,11 @@ MeshRenderer::MeshRenderer(ECSCore* pECS, Device* pDevice)
     m_pDescriptorSetLayoutMesh(nullptr),
     m_pDescriptorSetCommon(nullptr),
     m_pAniSampler(nullptr),
-    m_pRenderPass(nullptr),
     m_pPipelineLayout(nullptr),
     m_pPipeline(nullptr)
 {
     std::fill(m_ppCommandPools, m_ppCommandPools + MAX_FRAMES_IN_FLIGHT, nullptr);
     std::fill(m_ppCommandLists, m_ppCommandLists + MAX_FRAMES_IN_FLIGHT, nullptr);
-    std::fill(m_pFramebuffers, m_pFramebuffers + MAX_FRAMES_IN_FLIGHT, nullptr);
 
     CameraComponents camSub;
     PointLightComponents pointLightSub;
@@ -53,7 +52,6 @@ MeshRenderer::~MeshRenderer()
     }
 
     for (uint32_t frameIndex = 0u; frameIndex < MAX_FRAMES_IN_FLIGHT; frameIndex += 1u) {
-        delete m_pFramebuffers[frameIndex];
         delete m_ppCommandLists[frameIndex];
         delete m_ppCommandPools[frameIndex];
     }
@@ -63,7 +61,6 @@ MeshRenderer::~MeshRenderer()
     delete m_pDescriptorSetLayoutCommon;
     delete m_pDescriptorSetLayoutModel;
     delete m_pDescriptorSetLayoutMesh;
-    delete m_pRenderPass;
     delete m_pPipelineLayout;
     delete m_pPipeline;
 }
@@ -76,7 +73,7 @@ bool MeshRenderer::init()
             return false;
         }
 
-        m_ppCommandPools[frameIndex]->allocateCommandLists(&m_ppCommandLists[frameIndex], 1u, COMMAND_LIST_LEVEL::PRIMARY);
+        m_ppCommandPools[frameIndex]->allocateCommandLists(&m_ppCommandLists[frameIndex], 1u, COMMAND_LIST_LEVEL::SECONDARY);
         if (!m_ppCommandLists[frameIndex]) {
             return false;
         }
@@ -105,14 +102,6 @@ bool MeshRenderer::init()
     }
 
     if (!createCommonDescriptorSet()) {
-        return false;
-    }
-
-    if (!createRenderPass()) {
-        return false;
-    }
-
-    if (!createFramebuffers()) {
         return false;
     }
 
@@ -174,25 +163,12 @@ void MeshRenderer::recordCommands()
     ICommandList* pCommandList = m_ppCommandLists[frameIndex];
 
     CommandListBeginInfo beginInfo = {};
-    beginInfo.pRenderPass   = m_pRenderPass;
+    beginInfo.pRenderPass   = m_pRenderingHandler->getRenderPass();
     beginInfo.Subpass       = 0u;
-    beginInfo.pFramebuffer  = m_pFramebuffers[frameIndex];
-    pCommandList->begin(COMMAND_LIST_USAGE::ONE_TIME_SUBMIT, &beginInfo);
+    beginInfo.pFramebuffer  = m_pRenderingHandler->getCurrentFramebufferBackDepth();
+    pCommandList->begin(COMMAND_LIST_USAGE::WITHIN_RENDER_PASS, &beginInfo);
 
-    std::array<ClearValue, 2> pClearValues;
-    std::fill(pClearValues[0].ClearColorValue.uint32, &pClearValues[0].ClearColorValue.uint32[3], 0u);
-    pClearValues[1].DepthStencilValue.Depth     = 1.0f;
-    pClearValues[1].DepthStencilValue.Stencil   = 0u;
-
-    RenderPassBeginInfo renderPassBeginInfo = {};
-    renderPassBeginInfo.pFramebuffer        = m_pFramebuffers[frameIndex];
-    renderPassBeginInfo.pClearValues        = pClearValues.data();
-    renderPassBeginInfo.ClearValueCount     = (uint32_t)pClearValues.size();
-    renderPassBeginInfo.RecordingListType   = COMMAND_LIST_LEVEL::PRIMARY;
-
-    pCommandList->beginRenderPass(m_pRenderPass, renderPassBeginInfo);
-
-    if (m_Renderables.size() == 0 || m_Camera.size() == 0) {
+    if (m_Renderables.empty() || m_Camera.empty()) {
         pCommandList->end();
         return;
     }
@@ -207,7 +183,6 @@ void MeshRenderer::recordCommands()
         pCommandList->bindDescriptorSet(modelRenderResources.pDescriptorSet, m_pPipelineLayout);
 
         size_t meshIdx = 0;
-
         for (const Mesh& mesh : pModel->Meshes) {
             if (pModel->Materials[mesh.materialIndex].textures.empty()) {
                 // Will not render the mesh if it does not have a texture
@@ -227,14 +202,12 @@ void MeshRenderer::recordCommands()
         }
     }
 
-    pCommandList->endRenderPass();
     pCommandList->end();
 }
 
-void MeshRenderer::executeCommands()
+void MeshRenderer::executeCommands(ICommandList* pPrimaryCommandList)
 {
-    SemaphoreSubmitInfo semaphoreInfo = {};
-    m_pDevice->graphicsQueueSubmit(m_ppCommandLists[m_pDevice->getFrameIndex()], nullptr, semaphoreInfo);
+    pPrimaryCommandList->executeSecondaryCommandList(m_ppCommandLists[m_pDevice->getFrameIndex()]);
 }
 
 bool MeshRenderer::createBuffers()
@@ -292,79 +265,6 @@ bool MeshRenderer::createCommonDescriptorSet()
     }
 
     m_pDescriptorSetCommon->updateUniformBufferDescriptor(SHADER_BINDING::PER_FRAME, m_pPointLightBuffer);
-    return true;
-}
-
-bool MeshRenderer::createRenderPass()
-{
-    RenderPassInfo renderPassInfo   = {};
-
-    // Render pass attachments
-    Texture* pBackbuffer = m_pDevice->getBackbuffer(0u);
-    AttachmentInfo backBufferAttachment   = {};
-    backBufferAttachment.Format           = pBackbuffer->getFormat();
-    backBufferAttachment.Samples          = 1u;
-    backBufferAttachment.LoadOp           = ATTACHMENT_LOAD_OP::CLEAR;
-    backBufferAttachment.StoreOp          = ATTACHMENT_STORE_OP::STORE;
-    backBufferAttachment.InitialLayout    = TEXTURE_LAYOUT::UNDEFINED;
-    backBufferAttachment.FinalLayout      = TEXTURE_LAYOUT::RENDER_TARGET;
-
-    Texture* pDepthStencil = m_pDevice->getDepthStencil(0u);
-    AttachmentInfo depthStencilAttachment = {};
-    depthStencilAttachment.Format           = pDepthStencil->getFormat();
-    depthStencilAttachment.Samples          = 1u;
-    depthStencilAttachment.LoadOp           = ATTACHMENT_LOAD_OP::CLEAR;
-    depthStencilAttachment.StoreOp          = ATTACHMENT_STORE_OP::STORE;
-    depthStencilAttachment.InitialLayout    = TEXTURE_LAYOUT::UNDEFINED;
-    depthStencilAttachment.FinalLayout      = TEXTURE_LAYOUT::DEPTH_STENCIL_ATTACHMENT;
-
-    // Subpass
-    SubpassInfo subpass = {};
-    AttachmentReference backbufferRef   = {};
-    backbufferRef.AttachmentIndex       = 0;
-    backbufferRef.Layout                = TEXTURE_LAYOUT::RENDER_TARGET;
-
-    AttachmentReference depthStencilRef = {};
-    depthStencilRef.AttachmentIndex     = 1;
-    depthStencilRef.Layout              = TEXTURE_LAYOUT::DEPTH_STENCIL_ATTACHMENT;
-
-    subpass.ColorAttachments        = { backbufferRef };
-    subpass.pDepthStencilAttachment = &depthStencilRef;
-    subpass.PipelineBindPoint       = PIPELINE_BIND_POINT::GRAPHICS;
-
-    // Subpass dependency
-    SubpassDependency subpassDependency = {};
-    subpassDependency.SrcSubpass        = SUBPASS_EXTERNAL;
-    subpassDependency.DstSubpass        = 0;
-    subpassDependency.SrcStage          = PIPELINE_STAGE::BOTTOM_OF_PIPE;
-    subpassDependency.DstStage          = PIPELINE_STAGE::COLOR_ATTACHMENT_OUTPUT;
-    subpassDependency.SrcAccessMask     = RESOURCE_ACCESS::MEMORY_READ;
-    subpassDependency.DstAccessMask     = RESOURCE_ACCESS::COLOR_ATTACHMENT_READ | RESOURCE_ACCESS::COLOR_ATTACHMENT_WRITE;
-    subpassDependency.DependencyFlags   = DEPENDENCY_FLAG::BY_REGION;
-
-    renderPassInfo.AttachmentInfos  = { backBufferAttachment, depthStencilAttachment };
-    renderPassInfo.Subpasses        = { subpass };
-    renderPassInfo.Dependencies     = { subpassDependency };
-
-    m_pRenderPass = m_pDevice->createRenderPass(renderPassInfo);
-    return m_pRenderPass;
-}
-
-bool MeshRenderer::createFramebuffers()
-{
-    FramebufferInfo framebufferInfo = {};
-    framebufferInfo.pRenderPass = m_pRenderPass;
-    framebufferInfo.Dimensions  = m_pDevice->getBackbuffer(0u)->getDimensions();
-
-    for (uint32_t framebufferIdx = 0u; framebufferIdx < MAX_FRAMES_IN_FLIGHT; framebufferIdx += 1u) {
-        framebufferInfo.Attachments = { m_pDevice->getBackbuffer(framebufferIdx), m_pDevice->getDepthStencil(framebufferIdx) };
-        m_pFramebuffers[framebufferIdx] = m_pDevice->createFramebuffer(framebufferInfo);
-
-        if (!m_pFramebuffers[framebufferIdx]) {
-            return false;
-        }
-    }
-
     return true;
 }
 
@@ -428,7 +328,7 @@ bool MeshRenderer::createPipeline()
     }
 
     pipelineInfo.pLayout        = m_pPipelineLayout;
-    pipelineInfo.pRenderPass    = m_pRenderPass;
+    pipelineInfo.pRenderPass    = m_pRenderingHandler->getRenderPass();
     pipelineInfo.Subpass        = 0u;
 
     m_pPipeline = m_pDevice->createPipeline(pipelineInfo);

--- a/src/Engine/Rendering/MeshRenderer.hpp
+++ b/src/Engine/Rendering/MeshRenderer.hpp
@@ -31,14 +31,14 @@ struct ModelRenderResources {
 class MeshRenderer : public Renderer
 {
 public:
-    MeshRenderer(ECSCore* pECS, Device* pDevice);
+    MeshRenderer(ECSCore* pECS, Device* pDevice, RenderingHandler* pRenderingHandler);
     ~MeshRenderer();
 
     bool init() override final;
 
     void updateBuffers() override final;
     void recordCommands() override final;
-    void executeCommands() override final;
+    void executeCommands(ICommandList* pPrimaryCommandList) override final;
 
 private:
     struct PointLightBuffer {
@@ -63,8 +63,6 @@ private:
     bool createBuffers();
     bool createDescriptorSetLayouts();
     bool createCommonDescriptorSet();
-    bool createRenderPass();
-    bool createFramebuffers();
     bool createPipeline();
 
     void onMeshAdded(Entity entity);
@@ -97,8 +95,6 @@ private:
 
     ISampler* m_pAniSampler;
 
-    Framebuffer* m_pFramebuffers[MAX_FRAMES_IN_FLIGHT];
-    IRenderPass* m_pRenderPass;
     IPipeline* m_pPipeline;
     IPipelineLayout* m_pPipelineLayout;
 };

--- a/src/Engine/Rendering/RenderingHandler.cpp
+++ b/src/Engine/Rendering/RenderingHandler.cpp
@@ -9,12 +9,29 @@
 RenderingHandler::RenderingHandler(ECSCore* pECS, Device* pDevice)
     :m_pECS(pECS),
     m_pDevice(pDevice),
-    m_MeshRenderer(pECS, pDevice),
-    m_UIRenderer(pECS, pDevice)
-{}
+    m_MeshRenderer(pECS, pDevice, this),
+    m_UIRenderer(pECS, pDevice, this),
+    m_pRenderPass(nullptr),
+    m_pPrimaryBufferFence(nullptr)
+{
+    std::fill(&m_ppCommandPools[0u], &m_ppCommandPools[MAX_FRAMES_IN_FLIGHT], nullptr);
+    std::fill(&m_ppCommandLists[0u], &m_ppCommandLists[MAX_FRAMES_IN_FLIGHT], nullptr);
+    std::fill(&m_ppFramebuffersBackDepth[0u], &m_ppFramebuffersBackDepth[MAX_FRAMES_IN_FLIGHT], nullptr);
+    std::fill(&m_ppRenderingSemaphores[0u], &m_ppRenderingSemaphores[MAX_FRAMES_IN_FLIGHT], nullptr);
+}
 
 RenderingHandler::~RenderingHandler()
-{}
+{
+    for (uint32_t frameIndex = 0u; frameIndex < MAX_FRAMES_IN_FLIGHT; frameIndex += 1u) {
+        delete m_ppCommandPools[frameIndex];
+        delete m_ppCommandLists[frameIndex];
+        delete m_ppFramebuffersBackDepth[frameIndex];
+        delete m_ppRenderingSemaphores[frameIndex];
+    }
+
+    delete m_pPrimaryBufferFence;
+    delete m_pRenderPass;
+}
 
 bool RenderingHandler::init()
 {
@@ -23,23 +40,177 @@ bool RenderingHandler::init()
         &m_UIRenderer
     };
 
-    return true;
+    for (uint32_t frameIndex = 0u; frameIndex < MAX_FRAMES_IN_FLIGHT; frameIndex += 1u) {
+        m_ppCommandPools[frameIndex] = m_pDevice->createCommandPool(COMMAND_POOL_FLAG::RESETTABLE_COMMAND_LISTS, m_pDevice->getQueueFamilyIndices().Graphics);
+        if (!m_ppCommandPools[frameIndex]) {
+            return false;
+        }
+
+        m_ppCommandPools[frameIndex]->allocateCommandLists(&m_ppCommandLists[frameIndex], 1u, COMMAND_LIST_LEVEL::PRIMARY);
+        if (!m_ppCommandLists[frameIndex]) {
+            return false;
+        }
+
+        m_ppRenderingSemaphores[frameIndex] = m_pDevice->createSemaphore();
+        if (!m_ppRenderingSemaphores[frameIndex]) {
+            return false;
+        }
+    }
+
+    if (!createRenderPass()) {
+        return false;
+    }
+
+    if (!createFramebuffers()) {
+        return false;
+    }
+
+    m_pPrimaryBufferFence = m_pDevice->createFence(false);
+    return m_pPrimaryBufferFence;
 }
 
 void RenderingHandler::render()
 {
-    Swapchain* pSwapchain = m_pDevice->getSwapchain();
-    uint32_t& frameIndex = m_pDevice->getFrameIndex();
-    pSwapchain->acquireNextBackbuffer(frameIndex, SYNC_OPTION::FENCE);
-
-    IFence* pBackbufferReadyFence = pSwapchain->getFence();
-    m_pDevice->waitForFences(&pBackbufferReadyFence, 1u, false, UINT64_MAX);
+    beginFrame();
 
     updateBuffers();
     recordCommandBuffers();
     executeCommandBuffers();
 
-    pSwapchain->present(nullptr, 0u);
+    endFrame();
+}
+
+bool RenderingHandler::createRenderPass()
+{
+    RenderPassInfo renderPassInfo   = {};
+
+    // Render pass attachments
+    Texture* pBackbuffer = m_pDevice->getBackbuffer(0u);
+    AttachmentInfo backBufferAttachment   = {};
+    backBufferAttachment.Format           = pBackbuffer->getFormat();
+    backBufferAttachment.Samples          = 1u;
+    backBufferAttachment.LoadOp           = ATTACHMENT_LOAD_OP::CLEAR;
+    backBufferAttachment.StoreOp          = ATTACHMENT_STORE_OP::STORE;
+    backBufferAttachment.InitialLayout    = TEXTURE_LAYOUT::UNDEFINED;
+    backBufferAttachment.FinalLayout      = TEXTURE_LAYOUT::PRESENT;
+
+    Texture* pDepthStencil = m_pDevice->getDepthStencil(0u);
+    AttachmentInfo depthStencilAttachment = {};
+    depthStencilAttachment.Format           = pDepthStencil->getFormat();
+    depthStencilAttachment.Samples          = 1u;
+    depthStencilAttachment.LoadOp           = ATTACHMENT_LOAD_OP::CLEAR;
+    depthStencilAttachment.StoreOp          = ATTACHMENT_STORE_OP::STORE;
+    depthStencilAttachment.InitialLayout    = TEXTURE_LAYOUT::UNDEFINED;
+    depthStencilAttachment.FinalLayout      = TEXTURE_LAYOUT::DEPTH_STENCIL_ATTACHMENT;
+
+    // Mesh subpass
+    SubpassInfo meshSubpass = {};
+    AttachmentReference backbufferRef   = {};
+    backbufferRef.AttachmentIndex       = 0;
+    backbufferRef.Layout                = TEXTURE_LAYOUT::RENDER_TARGET;
+
+    AttachmentReference depthStencilRef = {};
+    depthStencilRef.AttachmentIndex     = 1;
+    depthStencilRef.Layout              = TEXTURE_LAYOUT::DEPTH_STENCIL_ATTACHMENT;
+
+    meshSubpass.ColorAttachments        = { backbufferRef };
+    meshSubpass.pDepthStencilAttachment = &depthStencilRef;
+    meshSubpass.PipelineBindPoint       = PIPELINE_BIND_POINT::GRAPHICS;
+
+    // Mesh subpass dependency
+    SubpassDependency meshSubpassDependency = {};
+    meshSubpassDependency.SrcSubpass        = SUBPASS_EXTERNAL;
+    meshSubpassDependency.DstSubpass        = 0;
+    meshSubpassDependency.SrcStage          = PIPELINE_STAGE::BOTTOM_OF_PIPE;
+    meshSubpassDependency.DstStage          = PIPELINE_STAGE::COLOR_ATTACHMENT_OUTPUT;
+    meshSubpassDependency.SrcAccessMask     = RESOURCE_ACCESS::MEMORY_READ;
+    meshSubpassDependency.DstAccessMask     = RESOURCE_ACCESS::COLOR_ATTACHMENT_READ | RESOURCE_ACCESS::COLOR_ATTACHMENT_WRITE;
+    meshSubpassDependency.DependencyFlags   = DEPENDENCY_FLAG::BY_REGION;
+
+    // UI subpass
+    SubpassInfo UISubpass = {};
+    UISubpass.ColorAttachments        = { backbufferRef };
+    UISubpass.pDepthStencilAttachment = &depthStencilRef;
+    UISubpass.PipelineBindPoint       = PIPELINE_BIND_POINT::GRAPHICS;
+
+    // UI subpass dependency
+    SubpassDependency UISubpassDependency = {};
+    UISubpassDependency.SrcSubpass        = 0u;
+    UISubpassDependency.DstSubpass        = 1u;
+    UISubpassDependency.SrcStage          = PIPELINE_STAGE::COLOR_ATTACHMENT_OUTPUT;
+    UISubpassDependency.DstStage          = PIPELINE_STAGE::COLOR_ATTACHMENT_OUTPUT;
+    UISubpassDependency.SrcAccessMask     = { };
+    UISubpassDependency.DstAccessMask     = RESOURCE_ACCESS::COLOR_ATTACHMENT_READ | RESOURCE_ACCESS::COLOR_ATTACHMENT_WRITE;
+    UISubpassDependency.DependencyFlags   = DEPENDENCY_FLAG::BY_REGION;
+
+    renderPassInfo.AttachmentInfos  = { backBufferAttachment, depthStencilAttachment };
+    renderPassInfo.Subpasses        = { meshSubpass, UISubpass };
+    renderPassInfo.Dependencies     = { meshSubpassDependency, UISubpassDependency };
+
+    m_pRenderPass = m_pDevice->createRenderPass(renderPassInfo);
+    return m_pRenderPass;
+}
+
+bool RenderingHandler::createFramebuffers()
+{
+    FramebufferInfo framebufferInfoBackDepth = {};
+    framebufferInfoBackDepth.pRenderPass     = m_pRenderPass;
+    framebufferInfoBackDepth.Dimensions      = m_pDevice->getBackbuffer(0u)->getDimensions();
+    framebufferInfoBackDepth.Attachments.resize(2u);
+
+    for (uint32_t frameIndex = 0u; frameIndex < MAX_FRAMES_IN_FLIGHT; frameIndex += 1u) {
+        framebufferInfoBackDepth.Attachments[0u] = m_pDevice->getBackbuffer(frameIndex);
+        framebufferInfoBackDepth.Attachments[1u] = m_pDevice->getDepthStencil(frameIndex);
+        m_ppFramebuffersBackDepth[frameIndex] = m_pDevice->createFramebuffer(framebufferInfoBackDepth);
+        if (!m_ppFramebuffersBackDepth[frameIndex]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void RenderingHandler::beginFrame()
+{
+    Swapchain* pSwapchain = m_pDevice->getSwapchain();
+    uint32_t& frameIndex = m_pDevice->getFrameIndex();
+    pSwapchain->acquireNextBackbuffer(frameIndex, SYNC_OPTION::SEMAPHORE);
+
+    m_pDevice->waitForFences(&m_pPrimaryBufferFence, 1u, false, UINT64_MAX);
+    m_pPrimaryBufferFence->reset();
+
+    m_ppCommandLists[frameIndex]->begin({}, nullptr);
+
+    // Begin render pass
+    std::array<ClearValue, 2> pClearValues;
+    std::fill(pClearValues[0].ClearColorValue.uint32, &pClearValues[0].ClearColorValue.uint32[3], 0u);
+    pClearValues[1].DepthStencilValue.Depth     = 1.0f;
+    pClearValues[1].DepthStencilValue.Stencil   = 0u;
+
+    RenderPassBeginInfo renderPassBeginInfo = {};
+    renderPassBeginInfo.pFramebuffer        = m_ppFramebuffersBackDepth[frameIndex];
+    renderPassBeginInfo.pClearValues        = pClearValues.data();
+    renderPassBeginInfo.ClearValueCount     = (uint32_t)pClearValues.size();
+    renderPassBeginInfo.RecordingListType   = COMMAND_LIST_LEVEL::SECONDARY;
+    m_ppCommandLists[frameIndex]->beginRenderPass(m_pRenderPass, renderPassBeginInfo);
+}
+
+void RenderingHandler::endFrame()
+{
+    const uint32_t frameIndex = m_pDevice->getFrameIndex();
+    m_ppCommandLists[frameIndex]->endRenderPass();
+    m_ppCommandLists[frameIndex]->end();
+
+    ISemaphore* pBackbufferReadySemaphore = m_pDevice->getSwapchain()->getSemaphore(frameIndex);
+
+    SemaphoreSubmitInfo semaphoreInfo = {};
+    semaphoreInfo.ppWaitSemaphores      = &pBackbufferReadySemaphore;
+    semaphoreInfo.WaitSemaphoreCount    = 1u;
+    semaphoreInfo.ppSignalSemaphores    = &m_ppRenderingSemaphores[frameIndex];
+    semaphoreInfo.SignalSemaphoreCount  = 1u;
+    m_pDevice->graphicsQueueSubmit(m_ppCommandLists[frameIndex], m_pPrimaryBufferFence, &semaphoreInfo);
+
+    m_pDevice->getSwapchain()->present(&m_ppRenderingSemaphores[frameIndex], 1u);
 }
 
 void RenderingHandler::updateBuffers()
@@ -72,6 +243,9 @@ void RenderingHandler::recordCommandBuffers()
 
 void RenderingHandler::executeCommandBuffers()
 {
-    m_MeshRenderer.executeCommands();
-    m_UIRenderer.executeCommands();
+    ICommandList* pPrimaryCommandList = m_ppCommandLists[m_pDevice->getFrameIndex()];
+
+    m_MeshRenderer.executeCommands(pPrimaryCommandList);
+    pPrimaryCommandList->nextSubpass(COMMAND_LIST_LEVEL::SECONDARY);
+    m_UIRenderer.executeCommands(pPrimaryCommandList);
 }

--- a/src/Engine/Rendering/RenderingHandler.hpp
+++ b/src/Engine/Rendering/RenderingHandler.hpp
@@ -13,7 +13,16 @@ public:
 
     void render();
 
+    inline ICommandList* getCurrentPrimaryCommandList()     { return m_ppCommandLists[m_pDevice->getFrameIndex()]; }
+    inline IRenderPass* getRenderPass()                     { return m_pRenderPass; }
+    inline Framebuffer* getCurrentFramebufferBackDepth()    { return m_ppFramebuffersBackDepth[m_pDevice->getFrameIndex()]; }
+
 private:
+    bool createRenderPass();
+    bool createFramebuffers();
+
+    void beginFrame();
+    void endFrame();
     void updateBuffers();
     void recordCommandBuffers();
     void executeCommandBuffers();
@@ -26,4 +35,14 @@ private:
 
     MeshRenderer m_MeshRenderer;
     UIRenderer m_UIRenderer;
+
+    // Primary command lists
+    ICommandPool* m_ppCommandPools[MAX_FRAMES_IN_FLIGHT];
+    ICommandList* m_ppCommandLists[MAX_FRAMES_IN_FLIGHT];
+
+    IRenderPass* m_pRenderPass;
+    Framebuffer* m_ppFramebuffersBackDepth[MAX_FRAMES_IN_FLIGHT];
+
+    ISemaphore* m_ppRenderingSemaphores[MAX_FRAMES_IN_FLIGHT];
+    IFence* m_pPrimaryBufferFence;
 };

--- a/src/Engine/UI/Panel.cpp
+++ b/src/Engine/UI/Panel.cpp
@@ -357,9 +357,7 @@ void UIHandler::renderTexturesOntoPanel(std::vector<TextureAttachment>& attachme
     m_pCommandList->end();
 
     IFence* pFence = m_pDevice->createFence(false);
-
-    SemaphoreSubmitInfo semaphoreInfo = {};
-    m_pDevice->graphicsQueueSubmit(m_pCommandList, pFence, semaphoreInfo);
+    m_pDevice->graphicsQueueSubmit(m_pCommandList, pFence, nullptr);
 
     // Delete render resources when rendering has finished
     std::thread deleterThread = std::thread([renderResources, pFramebuffer, pFence, this]() mutable {

--- a/src/Engine/UI/UIRenderer.hpp
+++ b/src/Engine/UI/UIRenderer.hpp
@@ -15,19 +15,17 @@ struct PanelRenderResources {
 class UIRenderer : public Renderer
 {
 public:
-    UIRenderer(ECSCore* pECS, Device* pDevice);
+    UIRenderer(ECSCore* pECS, Device* pDevice, RenderingHandler* pRenderingHandler);
     ~UIRenderer();
 
     bool init() override final;
 
     void updateBuffers() override final;
     void recordCommands() override final;
-    void executeCommands() override final;
+    void executeCommands(ICommandList* pPrimaryCommandList) override final;
 
 private:
     bool createDescriptorSetLayouts();
-    bool createRenderPass();
-    bool createFramebuffers();
     bool createPipeline();
 
     void onPanelAdded(Entity entity);
@@ -46,8 +44,6 @@ private:
     IBuffer* m_pQuad;
 
     ISampler* m_pAniSampler;
-    IRenderPass* m_pRenderPass;
-    Framebuffer* m_ppFramebuffers[MAX_FRAMES_IN_FLIGHT];
 
     IDescriptorSetLayout* m_pDescriptorSetLayout;
 


### PR DESCRIPTION
- Render passes are now created in the rendering handler, as opposed to in renderers
- Renderers now have secondary command buffers, which are executed by a primary command buffer in rendering handler