### PR TITLE
Move renderpasses back to renderers

### DIFF
--- a/src/Engine/Rendering/APIAbstractions/DX11/SwapchainDX11.cpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/SwapchainDX11.cpp
@@ -32,16 +32,16 @@ SwapchainDX11::~SwapchainDX11()
     delete m_pBackbuffer;
 }
 
-bool SwapchainDX11::acquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions)
-{
-    frameIndex = (frameIndex + 1u) % MAX_FRAMES_IN_FLIGHT;
-    return true;
-}
-
 void SwapchainDX11::present(ISemaphore** ppWaitSemaphores, uint32_t waitSemaphoreCount)
 {
     HRESULT hr = m_pSwapchain->Present(0, 0);
     if (FAILED(hr)) {
         LOG_WARNING("Failed to present swapchain buffer: %s", hresultToString(hr).c_str());
     }
+}
+
+bool SwapchainDX11::dAcquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions)
+{
+    frameIndex = (frameIndex + 1u) % MAX_FRAMES_IN_FLIGHT;
+    return true;
 }

--- a/src/Engine/Rendering/APIAbstractions/DX11/SwapchainDX11.hpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/SwapchainDX11.hpp
@@ -24,10 +24,12 @@ public:
     SwapchainDX11(const SwapchainInfoDX11& swapchainInfo, const ISemaphore* const * ppSemaphores, IFence* pFence);
     ~SwapchainDX11();
 
-    bool acquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions) override final;
     void present(ISemaphore** ppWaitSemaphores, uint32_t waitSemaphoreCount) override final;
 
     Texture* getBackbuffer(uint32_t frameIndex) override final { return m_pBackbuffer; }
+
+private:
+    bool dAcquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions) override final;
 
 private:
     IDXGISwapChain* m_pSwapchain;

--- a/src/Engine/Rendering/APIAbstractions/Swapchain.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Swapchain.cpp
@@ -1,7 +1,8 @@
 #include "Swapchain.hpp"
 
 Swapchain::Swapchain(const Texture* const * ppDepthTextures, const ISemaphore* const * ppSemaphores, IFence* pFence)
-    :m_pFence(pFence)
+    :m_pFence(pFence),
+    m_PreviousFrameIndex(0u)
 {
     std::memcpy(m_ppDepthTextures, ppDepthTextures, sizeof(Texture*) * MAX_FRAMES_IN_FLIGHT);
     std::memcpy(m_ppSemaphores, ppSemaphores, sizeof(ISemaphore*) * MAX_FRAMES_IN_FLIGHT);
@@ -15,4 +16,10 @@ Swapchain::~Swapchain()
     }
 
     delete m_pFence;
+}
+
+bool Swapchain::acquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions)
+{
+    m_PreviousFrameIndex = frameIndex;
+    return dAcquireNextBackbuffer(frameIndex, syncOptions);
 }

--- a/src/Engine/Rendering/APIAbstractions/Swapchain.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Swapchain.hpp
@@ -21,16 +21,22 @@ public:
 
     // Specifying fence as a sync option does not mean the CPU will block inside this function. The fence needs to be retrieved
     // and waited for separately.
-    virtual bool acquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions) = 0;
+    bool acquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions);
     virtual void present(ISemaphore** ppWaitSemaphores, uint32_t waitSemaphoreCount) = 0;
 
     virtual Texture* getBackbuffer(uint32_t frameIndex) = 0;
     inline Texture* getDepthTexture(uint32_t frameIndex)    { return m_ppDepthTextures[frameIndex]; }
-    inline ISemaphore* getSemaphore(uint32_t frameIndex)    { return m_ppSemaphores[frameIndex]; }
+    inline ISemaphore* getCurrentSemaphore()                       { return m_ppSemaphores[m_PreviousFrameIndex]; }
     inline IFence* getFence()                               { return m_pFence; }
 
 protected:
     Texture* m_ppDepthTextures[MAX_FRAMES_IN_FLIGHT];
     ISemaphore* m_ppSemaphores[MAX_FRAMES_IN_FLIGHT];
     IFence* m_pFence;
+
+private:
+    virtual bool dAcquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions) = 0;
+
+private:
+    uint32_t m_PreviousFrameIndex;
 };

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/SwapchainVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/SwapchainVK.cpp
@@ -34,32 +34,6 @@ SwapchainVK::~SwapchainVK()
     vkDestroySwapchainKHR(m_pDevice->getDevice(), m_Swapchain, nullptr);
 }
 
-bool SwapchainVK::acquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions)
-{
-    VkSemaphore semaphore = VK_NULL_HANDLE;
-    VkFence fence = VK_NULL_HANDLE;
-
-    if (HAS_FLAG(syncOptions, SYNC_OPTION::FENCE)) {
-        FenceVK* pFence = reinterpret_cast<FenceVK*>(m_pFence);
-        if (!pFence->reset()) {
-            return false;
-        }
-
-        fence = pFence->getFence();
-    }
-
-    if (HAS_FLAG(syncOptions, SYNC_OPTION::SEMAPHORE)) {
-        semaphore = reinterpret_cast<SemaphoreVK*>(m_ppSemaphores[frameIndex])->getSemaphore();
-    }
-
-    if (vkAcquireNextImageKHR(m_pDevice->getDevice(), m_Swapchain, UINT64_MAX, semaphore, fence, &frameIndex) != VK_SUCCESS) {
-        LOG_WARNING("Failed to acquire next swapchain image");
-        return false;
-    }
-
-    return true;
-}
-
 void SwapchainVK::present(ISemaphore** ppWaitSemaphores, uint32_t waitSemaphoreCount)
 {
     if (waitSemaphoreCount > (uint32_t)m_WaitSemaphores.size()) {
@@ -85,4 +59,30 @@ void SwapchainVK::present(ISemaphore** ppWaitSemaphores, uint32_t waitSemaphoreC
     if (vkQueuePresentKHR(presentQueue, &presentInfo) != VK_SUCCESS) {
         LOG_WARNING("Failed to present swapchain image");
     }
+}
+
+bool SwapchainVK::dAcquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions)
+{
+    VkSemaphore semaphore = VK_NULL_HANDLE;
+    VkFence fence = VK_NULL_HANDLE;
+
+    if (HAS_FLAG(syncOptions, SYNC_OPTION::FENCE)) {
+        FenceVK* pFence = reinterpret_cast<FenceVK*>(m_pFence);
+        if (!pFence->reset()) {
+            return false;
+        }
+
+        fence = pFence->getFence();
+    }
+
+    if (HAS_FLAG(syncOptions, SYNC_OPTION::SEMAPHORE)) {
+        semaphore = reinterpret_cast<SemaphoreVK*>(m_ppSemaphores[frameIndex])->getSemaphore();
+    }
+
+    if (vkAcquireNextImageKHR(m_pDevice->getDevice(), m_Swapchain, UINT64_MAX, semaphore, fence, &frameIndex) != VK_SUCCESS) {
+        LOG_WARNING("Failed to acquire next swapchain image");
+        return false;
+    }
+
+    return true;
 }

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/SwapchainVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/SwapchainVK.hpp
@@ -25,10 +25,12 @@ public:
     SwapchainVK(const SwapchainInfoVK& swapchainInfo, const ISemaphore* const * ppSemaphores, IFence* pFence);
     ~SwapchainVK();
 
-    bool acquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions) override final;
     void present(ISemaphore** ppWaitSemaphores, uint32_t waitSemaphoreCount) override final;
 
     Texture* getBackbuffer(uint32_t frameIndex) override final { return m_ppBackbuffers[frameIndex]; }
+
+private:
+    bool dAcquireNextBackbuffer(uint32_t& frameIndex, SYNC_OPTION syncOptions) override final;
 
 private:
     VkSwapchainKHR m_Swapchain;

--- a/src/Engine/Rendering/MeshRenderer.hpp
+++ b/src/Engine/Rendering/MeshRenderer.hpp
@@ -40,6 +40,9 @@ public:
     void recordCommands() override final;
     void executeCommands(ICommandList* pPrimaryCommandList) override final;
 
+    inline IRenderPass* getRenderPass()                     { return m_pRenderPass; }
+    inline Framebuffer* getFramebuffer(uint32_t frameIndex) { return m_ppFramebuffers[frameIndex]; }
+
 private:
     struct PointLightBuffer {
         DirectX::XMFLOAT3 Position;
@@ -63,6 +66,8 @@ private:
     bool createBuffers();
     bool createDescriptorSetLayouts();
     bool createCommonDescriptorSet();
+    bool createRenderPass();
+    bool createFramebuffers();
     bool createPipeline();
 
     void onMeshAdded(Entity entity);
@@ -95,6 +100,8 @@ private:
 
     ISampler* m_pAniSampler;
 
+    Framebuffer* m_ppFramebuffers[MAX_FRAMES_IN_FLIGHT];
+    IRenderPass* m_pRenderPass;
     IPipeline* m_pPipeline;
     IPipelineLayout* m_pPipelineLayout;
 };

--- a/src/Engine/Rendering/RenderingHandler.hpp
+++ b/src/Engine/Rendering/RenderingHandler.hpp
@@ -14,18 +14,13 @@ public:
     void render();
 
     inline ICommandList* getCurrentPrimaryCommandList()     { return m_ppCommandLists[m_pDevice->getFrameIndex()]; }
-    inline IRenderPass* getRenderPass()                     { return m_pRenderPass; }
-    inline Framebuffer* getCurrentFramebufferBackDepth()    { return m_ppFramebuffersBackDepth[m_pDevice->getFrameIndex()]; }
 
 private:
-    bool createRenderPass();
-    bool createFramebuffers();
-
     void beginFrame();
     void endFrame();
     void updateBuffers();
-    void recordCommandBuffers();
-    void executeCommandBuffers();
+    void recordSecondaryCommandBuffers();
+    void recordPrimaryCommandBuffer();
 
 private:
     ECSCore* m_pECS;
@@ -39,9 +34,6 @@ private:
     // Primary command lists
     ICommandPool* m_ppCommandPools[MAX_FRAMES_IN_FLIGHT];
     ICommandList* m_ppCommandLists[MAX_FRAMES_IN_FLIGHT];
-
-    IRenderPass* m_pRenderPass;
-    Framebuffer* m_ppFramebuffersBackDepth[MAX_FRAMES_IN_FLIGHT];
 
     ISemaphore* m_ppRenderingSemaphores[MAX_FRAMES_IN_FLIGHT];
     IFence* m_pPrimaryBufferFence;

--- a/src/Engine/UI/UIRenderer.hpp
+++ b/src/Engine/UI/UIRenderer.hpp
@@ -24,8 +24,13 @@ public:
     void recordCommands() override final;
     void executeCommands(ICommandList* pPrimaryCommandList) override final;
 
+    inline IRenderPass* getRenderPass()                     { return m_pRenderPass; }
+    inline Framebuffer* getFramebuffer(uint32_t frameIndex) { return m_ppFramebuffers[frameIndex]; }
+
 private:
     bool createDescriptorSetLayouts();
+    bool createRenderPass();
+    bool createFramebuffers();
     bool createPipeline();
 
     void onPanelAdded(Entity entity);
@@ -35,15 +40,16 @@ private:
     IDVector m_Panels;
     IDDVector<PanelRenderResources> m_PanelRenderResources;
 
+    UIHandler* m_pUIHandler;
+
     ICommandPool* m_ppCommandPools[MAX_FRAMES_IN_FLIGHT];
     ICommandList* m_ppCommandLists[MAX_FRAMES_IN_FLIGHT];
 
-    UIHandler* m_pUIHandler;
-
-    // Vertex buffer
     IBuffer* m_pQuad;
-
     ISampler* m_pAniSampler;
+
+    IRenderPass* m_pRenderPass;
+    Framebuffer* m_ppFramebuffers[MAX_FRAMES_IN_FLIGHT];
 
     IDescriptorSetLayout* m_pDescriptorSetLayout;
 


### PR DESCRIPTION
Found and fixed a bug where the swapchain would use the frame index to specify a semaphore to signal when a backbuffer is ready. The frame index would then be changed, and when the semaphore was meant to be retrieved again, the new frame index would be used to index the wrong semaphore.

When rendering with vulkan, the output in the main menu is now a black screen, which is better than before, when it was all white because no backbuffer was being presented.