### PR TITLE
Fix vulken buffer memory mapping not using offset

### DIFF
--- a/src/Engine/Rendering/APIAbstractions/Vulkan/BufferVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/BufferVK.cpp
@@ -147,7 +147,7 @@ bool BufferVK::mapCopyUnmap(const void* pData, VkDeviceSize size)
     VkDevice device = m_pDevice->getDevice();
     void* pMappedData = nullptr;
 
-    if (vkMapMemory(device, allocationInfo.deviceMemory, 0u, size, 0, &pMappedData) != VK_SUCCESS) {
+    if (vkMapMemory(device, allocationInfo.deviceMemory, allocationInfo.offset, size, 0, &pMappedData) != VK_SUCCESS) {
         LOG_WARNING("Failed to map buffer memory");
         return false;
     }

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.cpp
@@ -22,7 +22,6 @@ TextureVK* TextureVK::createFromFile(const std::string& filePath, DeviceVK* pDev
         return nullptr;
     }
 
-    // Let TextureVK::create handle the rest of the creation steps
     InitialData initialData = {};
     initialData.pData   = pPixelData;
     initialData.RowSize = 4u * (uint32_t)width;


### PR DESCRIPTION
This was causing textures to be offset horizontally.