### PR TITLE
Fix transition to game session and shutdown crashing on vulkan

### DIFF
--- a/assets/Engine/Shaders/Mesh_fs.glsl
+++ b/assets/Engine/Shaders/Mesh_fs.glsl
@@ -23,7 +23,6 @@ layout (set = 0, binding = 0) uniform PerFrame {
     vec4 Padding;
 } g_PerFrame;
 
-layout (location = 0) in vec4 in_Position;
 layout (location = 1) in vec3 in_Normal;
 layout (location = 2) in vec3 in_WorldPos;
 layout (location = 3) in vec2 in_TXCoords;

--- a/assets/Engine/Shaders/Mesh_vs.glsl
+++ b/assets/Engine/Shaders/Mesh_vs.glsl
@@ -9,7 +9,6 @@ layout (location = 0) in vec3 in_Position;
 layout (location = 1) in vec3 in_Normal;
 layout (location = 2) in vec2 in_TXCoords;
 
-layout (location = 0) out vec4 out_Position;
 layout (location = 1) out vec3 out_Normal;
 layout (location = 2) out vec3 out_WorldPos;
 layout (location = 3) out vec2 out_TXCoords;
@@ -19,7 +18,7 @@ void main()
     vec4 outPos         = vec4(in_Position, 1.0);
 
     vec4 outWorldPos    = g_PerObject.World * outPos;
-    out_Position        = g_PerObject.WVP * outPos;
+    gl_Position         = g_PerObject.WVP * outPos;
     out_Normal          = (g_PerObject.World * vec4(in_Normal, 0.0)).xyz;
     out_TXCoords        = in_TXCoords;
 }

--- a/src/Engine/GameState/StateManager.cpp
+++ b/src/Engine/GameState/StateManager.cpp
@@ -33,6 +33,7 @@ void StateManager::transitionState(State* pNewState, STATE_TRANSITION transition
             m_States.pop();
 
             if (!m_States.empty()) {
+                m_pECS->reinstateTopRegistryPage();
                 m_States.top()->resume();
             }
             break;

--- a/src/Engine/IGame.cpp
+++ b/src/Engine/IGame.cpp
@@ -18,6 +18,8 @@ IGame::IGame()
 
 IGame::~IGame()
 {
+    m_pDevice->waitIdle();
+
     delete m_pPhysicsCore;
     delete m_pAssetLoaders;
     delete m_pUICore;

--- a/src/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.cpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.cpp
@@ -111,7 +111,7 @@ void CommandListDX11::bindPipeline(IPipeline* pPipeline)
     m_pBoundPipeline = pPipelineDX;
 }
 
-void CommandListDX11::bindDescriptorSet(DescriptorSet* pDescriptorSet, IPipelineLayout* pPipelineLayout)
+void CommandListDX11::bindDescriptorSet(DescriptorSet* pDescriptorSet, IPipelineLayout* pPipelineLayout, uint32_t setNr)
 {
     DescriptorSetDX11* pDescriptorSetDX = reinterpret_cast<DescriptorSetDX11*>(pDescriptorSet);
     pDescriptorSetDX->bind(m_pContext);

--- a/src/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/CommandListDX11.hpp
@@ -31,7 +31,7 @@ public:
     void bindPipeline(IPipeline* pPipeline) override final;
 
     // Shader resources
-    void bindDescriptorSet(DescriptorSet* pDescriptorSet, IPipelineLayout* pPipelineLayout) override final;
+    void bindDescriptorSet(DescriptorSet* pDescriptorSet, IPipelineLayout* pPipelineLayout, uint32_t setNr) override final;
 
     void bindVertexBuffer(uint32_t firstBinding, IBuffer* pBuffer) override final;
     void bindIndexBuffer(IBuffer* pBuffer) override final;

--- a/src/Engine/Rendering/APIAbstractions/DX11/DescriptorPoolDX11.cpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/DescriptorPoolDX11.cpp
@@ -7,7 +7,7 @@ DescriptorPoolDX11::DescriptorPoolDX11(const DescriptorPoolInfo& poolInfo)
     :DescriptorPool(poolInfo)
 {}
 
-DescriptorSetDX11* DescriptorPoolDX11::allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout)
+DescriptorSetDX11* DescriptorPoolDX11::dAllocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout)
 {
     const DescriptorSetLayoutDX11* pDescriptorSetLayoutDX = reinterpret_cast<const DescriptorSetLayoutDX11*>(pDescriptorSetLayout);
     return DBG_NEW DescriptorSetDX11(pDescriptorSetLayoutDX, this);

--- a/src/Engine/Rendering/APIAbstractions/DX11/DescriptorPoolDX11.hpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/DescriptorPoolDX11.hpp
@@ -11,6 +11,7 @@ public:
     DescriptorPoolDX11(const DescriptorPoolInfo& poolInfo);
     ~DescriptorPoolDX11() = default;
 
-    DescriptorSetDX11* allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout) override final;
-    void deallocateDescriptorSet(const DescriptorSet* pDescriptorSet) override final { return; };
+private:
+    DescriptorSetDX11* dAllocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout) override final;
+    void dDeallocateDescriptorSet(const DescriptorSet* pDescriptorSet) override final { return; };
 };

--- a/src/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
+++ b/src/Engine/Rendering/APIAbstractions/DX11/DeviceDX11.hpp
@@ -63,6 +63,7 @@ public:
     std::string getShaderFileExtension() override final { return ".hlsl"; }
 
     bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) override final { return true; }
+    void waitIdle() override final {};
 
     ID3D11Device* getDevice()           { return m_pDevice; }
     ID3D11DeviceContext* getContext()   { return m_pContext; }

--- a/src/Engine/Rendering/APIAbstractions/DescriptorPool.cpp
+++ b/src/Engine/Rendering/APIAbstractions/DescriptorPool.cpp
@@ -5,16 +5,23 @@ DescriptorPool::DescriptorPool(const DescriptorPoolInfo& descriptorPoolInfo)
     m_DescriptorSetCapacity(descriptorPoolInfo.MaxSetAllocations)
 {}
 
-void DescriptorPool::allocatedDescriptorSet(const DescriptorCounts& descriptorCounts)
+DescriptorSet* DescriptorPool::allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout, const DescriptorCounts& descriptorCounts)
 {
-    m_AvailableDescriptors -= descriptorCounts;
-    m_DescriptorSetCapacity += 1u;
+    DescriptorSet* pNewSet = dAllocateDescriptorSet(pDescriptorSetLayout);
+    if (pNewSet) {
+        m_AvailableDescriptors -= descriptorCounts;
+        m_DescriptorSetCapacity -= 1u;
+    }
+
+    return pNewSet;
 }
 
-void DescriptorPool::deallocatedDescriptorSet(const DescriptorCounts& descriptorCounts)
+void DescriptorPool::deallocateDescriptorSet(const DescriptorSet* pDescriptorSet, const DescriptorCounts& descriptorCounts)
 {
+    dDeallocateDescriptorSet(pDescriptorSet);
+
     m_AvailableDescriptors += descriptorCounts;
-    m_DescriptorSetCapacity -= 1u;
+    m_DescriptorSetCapacity += 1u;
 }
 
 bool DescriptorPool::hasRoomFor(const DescriptorCounts& descriptorCounts)

--- a/src/Engine/Rendering/APIAbstractions/DescriptorPool.hpp
+++ b/src/Engine/Rendering/APIAbstractions/DescriptorPool.hpp
@@ -17,17 +17,17 @@ public:
     DescriptorPool(const DescriptorPoolInfo& descriptorPoolInfo);
     virtual ~DescriptorPool() = 0 {};
 
-    virtual DescriptorSet* allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout) = 0;
-    virtual void deallocateDescriptorSet(const DescriptorSet* pDescriptorSet) = 0;
-
-    // Increase or decrease the capacity after allocating or deallocating a descripotr set
-    void allocatedDescriptorSet(const DescriptorCounts& descriptorCounts);
-    void deallocatedDescriptorSet(const DescriptorCounts& descriptorCounts);
+    DescriptorSet* allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout, const DescriptorCounts& descriptorCounts);
+    void deallocateDescriptorSet(const DescriptorSet* pDescriptorSet, const DescriptorCounts& descriptorCounts);
 
     bool hasRoomFor(const DescriptorCounts& descriptorCounts);
 
 protected:
     DescriptorCounts m_AvailableDescriptors;
+
+private:
+    virtual DescriptorSet* dAllocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout) = 0;
+    virtual void dDeallocateDescriptorSet(const DescriptorSet* pDescriptorSet) = 0;
 
 private:
     // The amount of additional descriptor sets the pool is able to allocate

--- a/src/Engine/Rendering/APIAbstractions/DescriptorPoolHandler.cpp
+++ b/src/Engine/Rendering/APIAbstractions/DescriptorPoolHandler.cpp
@@ -7,9 +7,7 @@
 
 DescriptorPoolHandler::~DescriptorPoolHandler()
 {
-    for (DescriptorPool* pDescriptorPool : m_DescriptorPools) {
-        delete pDescriptorPool;
-    }
+    clear();
 }
 
 void DescriptorPoolHandler::init(const DescriptorPoolInfo& poolInfos, Device* pDevice)
@@ -17,6 +15,15 @@ void DescriptorPoolHandler::init(const DescriptorPoolInfo& poolInfos, Device* pD
     m_PoolInfos = poolInfos;
 
     m_DescriptorPools.push_back(pDevice->createDescriptorPool(poolInfos));
+}
+
+void DescriptorPoolHandler::clear()
+{
+    for (DescriptorPool* pDescriptorPool : m_DescriptorPools) {
+        delete pDescriptorPool;
+    }
+
+    m_DescriptorPools.clear();
 }
 
 DescriptorSet* DescriptorPoolHandler::allocateDescriptorSet(const IDescriptorSetLayout* pLayout, Device* pDevice)

--- a/src/Engine/Rendering/APIAbstractions/DescriptorPoolHandler.cpp
+++ b/src/Engine/Rendering/APIAbstractions/DescriptorPoolHandler.cpp
@@ -33,10 +33,9 @@ DescriptorSet* DescriptorPoolHandler::allocateDescriptorSet(const IDescriptorSet
 
     for (DescriptorPool* pDescriptorPool : m_DescriptorPools) {
         if (pDescriptorPool->hasRoomFor(descriptorsToAllocate)) {
-            pDescriptorSet = pDescriptorPool->allocateDescriptorSet(pLayout);
+            pDescriptorSet = pDescriptorPool->allocateDescriptorSet(pLayout, descriptorsToAllocate);
 
             if (pDescriptorSet) {
-                pDescriptorPool->allocatedDescriptorSet(descriptorsToAllocate);
                 return pDescriptorSet;
             }
         }
@@ -53,7 +52,7 @@ DescriptorSet* DescriptorPoolHandler::allocateDescriptorSet(const IDescriptorSet
     m_DescriptorPools.push_back(pDevice->createDescriptorPool(newPoolInfo));
 
     // Last attempt to allocate descriptor set
-    pDescriptorSet = m_DescriptorPools.back()->allocateDescriptorSet(pLayout);
+    pDescriptorSet = m_DescriptorPools.back()->allocateDescriptorSet(pLayout, descriptorsToAllocate);
     if (!pDescriptorSet) {
         LOG_ERROR("Failed to allocate descriptor set");
     }

--- a/src/Engine/Rendering/APIAbstractions/DescriptorPoolHandler.hpp
+++ b/src/Engine/Rendering/APIAbstractions/DescriptorPoolHandler.hpp
@@ -15,6 +15,7 @@ public:
 
     // Specify the settingsfor pools that will be created. Optimally, only one pool will be created, but more can be created if needed.
     void init(const DescriptorPoolInfo& poolInfos, Device* pDevice);
+    void clear();
 
     DescriptorSet* allocateDescriptorSet(const IDescriptorSetLayout* pLayout, Device* pDevice);
 

--- a/src/Engine/Rendering/APIAbstractions/DescriptorSet.cpp
+++ b/src/Engine/Rendering/APIAbstractions/DescriptorSet.cpp
@@ -10,6 +10,5 @@ DescriptorSet::DescriptorSet(DescriptorPool* pDescriptorPool, const IDescriptorS
 
 DescriptorSet::~DescriptorSet()
 {
-    m_pDescriptorPool->deallocateDescriptorSet(this);
-    m_pDescriptorPool->deallocatedDescriptorSet(reinterpret_cast<const DescriptorSetLayoutDX11*>(m_pLayout)->getDescriptorCounts());
+    m_pDescriptorPool->deallocateDescriptorSet(this, m_pLayout->getDescriptorCounts());
 }

--- a/src/Engine/Rendering/APIAbstractions/Device.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Device.cpp
@@ -124,6 +124,15 @@ Shader* Device::createShader(SHADER_TYPE shaderType, const std::string& filePath
     return pShader;
 }
 
+void Device::deleteGraphicsObjects()
+{
+    delete m_pSwapchain;
+    m_DescriptorPoolHandler.clear();
+    m_CommandPoolsTempGraphics.clear();
+    m_CommandPoolsTempTransfer.clear();
+    m_CommandPoolsTempCompute.clear();
+}
+
 bool Device::initTempCommandPools()
 {
     // Create pool of command pools

--- a/src/Engine/Rendering/APIAbstractions/ICommandList.hpp
+++ b/src/Engine/Rendering/APIAbstractions/ICommandList.hpp
@@ -49,7 +49,7 @@ public:
     virtual void bindPipeline(IPipeline* pPipeline) = 0;
 
     // Shader resources
-    virtual void bindDescriptorSet(DescriptorSet* pDescriptorSet, IPipelineLayout* pPipelineLayout) = 0;
+    virtual void bindDescriptorSet(DescriptorSet* pDescriptorSet, IPipelineLayout* pPipelineLayout, uint32_t setNr) = 0;
 
     virtual void bindVertexBuffer(uint32_t firstBinding, IBuffer* pBuffer) = 0;
     virtual void bindIndexBuffer(IBuffer* pBuffer) = 0;

--- a/src/Engine/Rendering/APIAbstractions/RenderPass.hpp
+++ b/src/Engine/Rendering/APIAbstractions/RenderPass.hpp
@@ -71,13 +71,13 @@ struct ClearDepthStencilValue {
     uint32_t Stencil;
 };
 
-struct ClearColorValue {
+union ClearColorValue {
     float       float32[4];
     int32_t     int32[4];
     uint32_t    uint32[4];
 };
 
-struct ClearValue {
+union ClearValue {
     ClearColorValue ClearColorValue;
     ClearDepthStencilValue DepthStencilValue;
 };

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.cpp
@@ -75,12 +75,12 @@ void CommandListVK::bindPipeline(IPipeline* pPipeline)
     vkCmdBindPipeline(m_CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
 }
 
-void CommandListVK::bindDescriptorSet(DescriptorSet* pDescriptorSet, IPipelineLayout* pPipelineLayout)
+void CommandListVK::bindDescriptorSet(DescriptorSet* pDescriptorSet, IPipelineLayout* pPipelineLayout, uint32_t setNr)
 {
     VkDescriptorSet descriptorSet   = reinterpret_cast<DescriptorSetVK*>(pDescriptorSet)->getDescriptorSet();
     VkPipelineLayout pipelineLayout = reinterpret_cast<PipelineLayoutVK*>(pPipelineLayout)->getPipelineLayout();
 
-    vkCmdBindDescriptorSets(m_CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0u, 1u, &descriptorSet, 0u, nullptr);
+    vkCmdBindDescriptorSets(m_CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, setNr, 1u, &descriptorSet, 0u, nullptr);
 }
 
 void CommandListVK::bindVertexBuffer(uint32_t firstBinding, IBuffer* pBuffer)

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.cpp
@@ -15,11 +15,6 @@ CommandListVK::CommandListVK(VkCommandBuffer commandBuffer, VkCommandPool comman
     m_pDevice(pDevice)
 {}
 
-CommandListVK::~CommandListVK()
-{
-    vkFreeCommandBuffers(m_pDevice->getDevice(), m_CommandPool, 1u, &m_CommandBuffer);
-}
-
 bool CommandListVK::begin(COMMAND_LIST_USAGE usageFlags, CommandListBeginInfo* pBeginInfo)
 {
     VkCommandBufferBeginInfo beginInfo = {};

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp
@@ -8,7 +8,7 @@ class CommandListVK : public ICommandList
 {
 public:
     CommandListVK(VkCommandBuffer commandBuffer, VkCommandPool commandPool, DeviceVK* pDevice);
-    ~CommandListVK();
+    ~CommandListVK() = default;
 
     bool begin(COMMAND_LIST_USAGE usageFlags, CommandListBeginInfo* pBeginInfo) override final;
     bool reset() override final;

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.hpp
@@ -22,7 +22,7 @@ public:
     void bindPipeline(IPipeline* pPipeline) override final;
 
     // Shader resources
-    void bindDescriptorSet(DescriptorSet* pDescriptorSet, IPipelineLayout* pPipelineLayout) override final;
+    void bindDescriptorSet(DescriptorSet* pDescriptorSet, IPipelineLayout* pPipelineLayout, uint32_t setNr) override final;
 
     void bindVertexBuffer(uint32_t firstBinding, IBuffer* pBuffer) override final;
     void bindIndexBuffer(IBuffer* pBuffer) override final;

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.cpp
@@ -50,7 +50,7 @@ DescriptorPoolVK::~DescriptorPoolVK()
     vkDestroyDescriptorPool(m_pDevice->getDevice(), m_DescriptorPool, nullptr);
 }
 
-DescriptorSetVK* DescriptorPoolVK::allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout)
+DescriptorSetVK* DescriptorPoolVK::dAllocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout)
 {
     VkDescriptorSetLayout layout = reinterpret_cast<const DescriptorSetLayoutVK*>(pDescriptorSetLayout)->getDescriptorSetLayout();
 
@@ -70,7 +70,7 @@ DescriptorSetVK* DescriptorPoolVK::allocateDescriptorSet(const IDescriptorSetLay
     return DBG_NEW DescriptorSetVK(descriptorSet, this, pLayoutVK, m_pDevice);
 }
 
-void DescriptorPoolVK::deallocateDescriptorSet(const DescriptorSet* pDescriptorSet)
+void DescriptorPoolVK::dDeallocateDescriptorSet(const DescriptorSet* pDescriptorSet)
 {
     VkDescriptorSet descriptorSet = reinterpret_cast<const DescriptorSetVK*>(pDescriptorSet)->getDescriptorSet();
     if (vkFreeDescriptorSets(m_pDevice->getDevice(), m_DescriptorPool, 1u, &descriptorSet) != VK_SUCCESS) {

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/DescriptorPoolVK.hpp
@@ -16,10 +16,11 @@ public:
     DescriptorPoolVK(VkDescriptorPool descriptorPool, const DescriptorPoolInfo& poolInfo, DeviceVK* pDevice);
     ~DescriptorPoolVK();
 
-    DescriptorSetVK* allocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout) override final;
-    void deallocateDescriptorSet(const DescriptorSet* pDescriptorSet) override final;
-
     inline VkDescriptorPool getDescriptorPool() { return m_DescriptorPool; }
+
+private:
+    DescriptorSetVK* dAllocateDescriptorSet(const IDescriptorSetLayout* pDescriptorSetLayout) override final;
+    void dDeallocateDescriptorSet(const DescriptorSet* pDescriptorSet) override final;
 
 private:
     VkDescriptorPool m_DescriptorPool;

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.cpp
@@ -35,6 +35,9 @@ DeviceVK::DeviceVK(const DeviceInfoVK& deviceInfo)
 
 DeviceVK::~DeviceVK()
 {
+    deleteGraphicsObjects();
+    vmaDestroyAllocator(m_Allocator);
+
     #ifdef _DEBUG
         auto destroyDebugUtilsMessengerEXT = (PFN_vkDestroyDebugUtilsMessengerEXT) vkGetInstanceProcAddr(m_Instance, "vkDestroyDebugUtilsMessengerEXT");
         if (destroyDebugUtilsMessengerEXT) {
@@ -44,9 +47,6 @@ DeviceVK::~DeviceVK()
         }
     #endif
 
-    delete m_pSwapchain;
-
-    vmaDestroyAllocator(m_Allocator);
     vkDestroyDevice(m_Device, nullptr);
     vkDestroySurfaceKHR(m_Instance, m_Surface, nullptr);
     vkDestroyInstance(m_Instance, nullptr);
@@ -224,6 +224,13 @@ bool DeviceVK::waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAl
     }
 
     return vkWaitForFences(m_Device, fenceCount, fences.data(), (VkBool32)waitAll, timeout) == VK_SUCCESS;
+}
+
+void DeviceVK::waitIdle()
+{
+    if (vkDeviceWaitIdle(m_Device) != VK_SUCCESS) {
+        LOG_WARNING("Failed to wait for device to become idle");
+    }
 }
 
 DescriptorPool* DeviceVK::createDescriptorPool(const DescriptorPoolInfo& poolInfo)

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/DeviceVK.hpp
@@ -68,6 +68,7 @@ public:
     std::string getShaderFileExtension() override final { return ".spv"; }
 
     bool waitForFences(IFence** ppFences, uint32_t fenceCount, bool waitAll, uint64_t timeout) override final;
+    void waitIdle() override final;
 
     VmaAllocator getVulkanAllocator()   { return m_Allocator; }
     VkDevice getDevice()                { return m_Device; }

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/SwapchainVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/SwapchainVK.cpp
@@ -31,6 +31,12 @@ SwapchainVK::SwapchainVK(const SwapchainInfoVK& swapchainInfo, const ISemaphore*
 
 SwapchainVK::~SwapchainVK()
 {
+    for (TextureVK* pBackbuffer : m_ppBackbuffers) {
+        // Deleting VkSwapchain also deletes its images
+        pBackbuffer->setImage(VK_NULL_HANDLE);
+        delete pBackbuffer;
+    }
+
     vkDestroySwapchainKHR(m_pDevice->getDevice(), m_Swapchain, nullptr);
 }
 

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.cpp
@@ -120,10 +120,15 @@ TextureVK::TextureVK(const glm::uvec2& dimensions, RESOURCE_FORMAT format, Devic
 TextureVK::~TextureVK()
 {
     VkDevice device = m_pDevice->getDevice();
-
     vkDestroyImageView(device, m_ImageView, nullptr);
-    vkDestroyImage(device, m_Image, nullptr);
-    vmaFreeMemory(m_pDevice->getVulkanAllocator(), m_Allocation);
+
+    if (m_Image != VK_NULL_HANDLE) {
+        vkDestroyImage(device, m_Image, nullptr);
+    }
+
+    if (m_Allocation != VK_NULL_HANDLE) {
+        vmaFreeMemory(m_pDevice->getVulkanAllocator(), m_Allocation);
+    }
 }
 
 bool TextureVK::convertTextureLayout(VkCommandBuffer commandBuffer, TEXTURE_LAYOUT srcLayout, TEXTURE_LAYOUT dstLayout, PIPELINE_STAGE srcStage, PIPELINE_STAGE dstStage)

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/TextureVK.hpp
@@ -38,6 +38,8 @@ public:
 
     bool convertTextureLayout(VkCommandBuffer commandBuffer, TEXTURE_LAYOUT srcLayout, TEXTURE_LAYOUT dstLayout, PIPELINE_STAGE srcStage, PIPELINE_STAGE dstStage);
 
+    inline void setImage(VkImage image)     { m_Image = image; }
+
     inline VkImage getImage()               { return m_Image; }
     inline VkImageView getImageView() const { return m_ImageView; }
 

--- a/src/Engine/Rendering/MeshRenderer.cpp
+++ b/src/Engine/Rendering/MeshRenderer.cpp
@@ -186,13 +186,13 @@ void MeshRenderer::recordCommands()
     }
 
     pCommandList->bindPipeline(m_pPipeline);
-    pCommandList->bindDescriptorSet(m_pDescriptorSetCommon, m_pPipelineLayout);
+    pCommandList->bindDescriptorSet(m_pDescriptorSetCommon, m_pPipelineLayout, 0u);
 
     for (Entity renderableID : m_Renderables.getIDs()) {
         Model* pModel = m_pModelLoader->getModel(renderableID);
         const ModelRenderResources& modelRenderResources = m_ModelRenderResources.indexID(renderableID);
 
-        pCommandList->bindDescriptorSet(modelRenderResources.pDescriptorSet, m_pPipelineLayout);
+        pCommandList->bindDescriptorSet(modelRenderResources.pDescriptorSet, m_pPipelineLayout, 1u);
 
         size_t meshIdx = 0;
         for (const Mesh& mesh : pModel->Meshes) {
@@ -201,16 +201,14 @@ void MeshRenderer::recordCommands()
                 continue;
             }
 
-            const MeshRenderResources& meshRenderResources = modelRenderResources.MeshRenderResources[meshIdx];
+            const MeshRenderResources& meshRenderResources = modelRenderResources.MeshRenderResources[meshIdx++];
 
             pCommandList->bindVertexBuffer(0, mesh.pVertexBuffer);
             pCommandList->bindIndexBuffer(mesh.pIndexBuffer);
 
-            pCommandList->bindDescriptorSet(meshRenderResources.pDescriptorSet, m_pPipelineLayout);
+            pCommandList->bindDescriptorSet(meshRenderResources.pDescriptorSet, m_pPipelineLayout, 2u);
 
             pCommandList->drawIndexed(mesh.indexCount);
-
-            meshIdx += 1;
         }
     }
 

--- a/src/Engine/Rendering/RenderingHandler.cpp
+++ b/src/Engine/Rendering/RenderingHandler.cpp
@@ -9,31 +9,33 @@
 RenderingHandler::RenderingHandler(ECSCore* pECS, Device* pDevice)
     :m_pECS(pECS),
     m_pDevice(pDevice),
-    m_MeshRenderer(pECS, pDevice, this),
-    m_UIRenderer(pECS, pDevice, this),
-    m_pPrimaryBufferFence(nullptr)
+    m_pMeshRenderer(new MeshRenderer(pECS, pDevice, this)),
+    m_pUIRenderer(new UIRenderer(pECS, pDevice, this))
 {
     std::fill(&m_ppCommandPools[0u], &m_ppCommandPools[MAX_FRAMES_IN_FLIGHT], nullptr);
     std::fill(&m_ppCommandLists[0u], &m_ppCommandLists[MAX_FRAMES_IN_FLIGHT], nullptr);
     std::fill(&m_ppRenderingSemaphores[0u], &m_ppRenderingSemaphores[MAX_FRAMES_IN_FLIGHT], nullptr);
+    std::fill(&m_ppPrimaryBufferFences[0u], &m_ppPrimaryBufferFences[MAX_FRAMES_IN_FLIGHT], nullptr);
 }
 
 RenderingHandler::~RenderingHandler()
 {
+    delete m_pMeshRenderer;
+    delete m_pUIRenderer;
+
     for (uint32_t frameIndex = 0u; frameIndex < MAX_FRAMES_IN_FLIGHT; frameIndex += 1u) {
         delete m_ppCommandPools[frameIndex];
         delete m_ppCommandLists[frameIndex];
         delete m_ppRenderingSemaphores[frameIndex];
+        delete m_ppPrimaryBufferFences[frameIndex];
     }
-
-    delete m_pPrimaryBufferFence;
 }
 
 bool RenderingHandler::init()
 {
     m_Renderers = {
-        &m_MeshRenderer,
-        &m_UIRenderer
+        m_pMeshRenderer,
+        m_pUIRenderer
     };
 
     for (uint32_t frameIndex = 0u; frameIndex < MAX_FRAMES_IN_FLIGHT; frameIndex += 1u) {
@@ -51,10 +53,14 @@ bool RenderingHandler::init()
         if (!m_ppRenderingSemaphores[frameIndex]) {
             return false;
         }
+
+        m_ppPrimaryBufferFences[frameIndex] = m_pDevice->createFence(true);
+        if (!m_ppPrimaryBufferFences[frameIndex]) {
+            return false;
+        }
     }
 
-    m_pPrimaryBufferFence = m_pDevice->createFence(true);
-    return m_pPrimaryBufferFence;
+    return true;
 }
 
 void RenderingHandler::render()
@@ -68,14 +74,26 @@ void RenderingHandler::render()
     endFrame();
 }
 
+void RenderingHandler::waitAllFrames()
+{
+    // Calling waitForFences with waitAll is dangerous as the goal is to always have a frame being rendered.
+    // Instead, wait for each fence one by one.
+    // Start by waiting for the upcoming frame's fence. It's the most likely to be signaled first
+    uint32_t frameIndex = (m_pDevice->getFrameIndex() + 1u) % MAX_FRAMES_IN_FLIGHT;
+    for (uint32_t waitedFrameCount = 0u; waitedFrameCount < MAX_FRAMES_IN_FLIGHT; waitedFrameCount += 1u) {
+        m_pDevice->waitForFences(&m_ppPrimaryBufferFences[frameIndex], 1u, false, UINT64_MAX);
+        frameIndex = (frameIndex + 1u) % MAX_FRAMES_IN_FLIGHT;
+    }
+}
+
 void RenderingHandler::beginFrame()
 {
     Swapchain* pSwapchain = m_pDevice->getSwapchain();
     uint32_t& frameIndex = m_pDevice->getFrameIndex();
     pSwapchain->acquireNextBackbuffer(frameIndex, SYNC_OPTION::SEMAPHORE);
 
-    m_pDevice->waitForFences(&m_pPrimaryBufferFence, 1u, false, UINT64_MAX);
-    m_pPrimaryBufferFence->reset();
+    m_pDevice->waitForFences(&m_ppPrimaryBufferFences[frameIndex], 1u, false, UINT64_MAX);
+    m_ppPrimaryBufferFences[frameIndex]->reset();
 
     m_ppCommandLists[frameIndex]->begin({}, nullptr);
 }
@@ -93,7 +111,7 @@ void RenderingHandler::endFrame()
     semaphoreInfo.pWaitStageFlags       = &waitStage;
     semaphoreInfo.ppSignalSemaphores    = &m_ppRenderingSemaphores[frameIndex];
     semaphoreInfo.SignalSemaphoreCount  = 1u;
-    m_pDevice->graphicsQueueSubmit(m_ppCommandLists[frameIndex], m_pPrimaryBufferFence, &semaphoreInfo);
+    m_pDevice->graphicsQueueSubmit(m_ppCommandLists[frameIndex], m_ppPrimaryBufferFences[frameIndex], &semaphoreInfo);
 
     m_pDevice->getSwapchain()->present(&m_ppRenderingSemaphores[frameIndex], 1u);
 }
@@ -133,27 +151,27 @@ void RenderingHandler::recordPrimaryCommandBuffer()
 
     // Begin mesh render pass
     std::array<ClearValue, 2> pClearValues;
-    std::fill(pClearValues[0].ClearColorValue.uint32, &pClearValues[0].ClearColorValue.uint32[3], 0u);
+    std::fill(&pClearValues[0].ClearColorValue.uint32[0], &pClearValues[0].ClearColorValue.uint32[4], 0u);
     pClearValues[1].DepthStencilValue.Depth     = 1.0f;
     pClearValues[1].DepthStencilValue.Stencil   = 0u;
 
     RenderPassBeginInfo renderPassBeginInfo = {};
-    renderPassBeginInfo.pFramebuffer        = m_MeshRenderer.getFramebuffer(frameIndex);
+    renderPassBeginInfo.pFramebuffer        = m_pMeshRenderer->getFramebuffer(frameIndex);
     renderPassBeginInfo.pClearValues        = pClearValues.data();
     renderPassBeginInfo.ClearValueCount     = (uint32_t)pClearValues.size();
     renderPassBeginInfo.RecordingListType   = COMMAND_LIST_LEVEL::SECONDARY;
-    m_ppCommandLists[frameIndex]->beginRenderPass(m_MeshRenderer.getRenderPass(), renderPassBeginInfo);
+    m_ppCommandLists[frameIndex]->beginRenderPass(m_pMeshRenderer->getRenderPass(), renderPassBeginInfo);
 
-    m_MeshRenderer.executeCommands(pPrimaryCommandList);
+    m_pMeshRenderer->executeCommands(pPrimaryCommandList);
 
     pPrimaryCommandList->endRenderPass();
 
     // Begin UI render pass
-    renderPassBeginInfo.pFramebuffer    = m_UIRenderer.getFramebuffer(frameIndex);
+    renderPassBeginInfo.pFramebuffer    = m_pUIRenderer->getFramebuffer(frameIndex);
     renderPassBeginInfo.ClearValueCount = 0u;
-    m_ppCommandLists[frameIndex]->beginRenderPass(m_UIRenderer.getRenderPass(), renderPassBeginInfo);
+    m_ppCommandLists[frameIndex]->beginRenderPass(m_pUIRenderer->getRenderPass(), renderPassBeginInfo);
 
-    m_UIRenderer.executeCommands(pPrimaryCommandList);
+    m_pUIRenderer->executeCommands(pPrimaryCommandList);
 
     m_ppCommandLists[frameIndex]->endRenderPass();
     m_ppCommandLists[frameIndex]->end();

--- a/src/Engine/Rendering/RenderingHandler.hpp
+++ b/src/Engine/Rendering/RenderingHandler.hpp
@@ -13,7 +13,11 @@ public:
 
     void render();
 
+    // waitALlFrames blocks the calling thread until all currently queued command lists have finished executing
+    void waitAllFrames();
+
     inline ICommandList* getCurrentPrimaryCommandList()     { return m_ppCommandLists[m_pDevice->getFrameIndex()]; }
+    inline IFence** getFences()                             { return m_ppPrimaryBufferFences; }
 
 private:
     void beginFrame();
@@ -28,13 +32,13 @@ private:
 
     std::vector<Renderer*> m_Renderers;
 
-    MeshRenderer m_MeshRenderer;
-    UIRenderer m_UIRenderer;
+    MeshRenderer* m_pMeshRenderer;
+    UIRenderer* m_pUIRenderer;
 
     // Primary command lists
     ICommandPool* m_ppCommandPools[MAX_FRAMES_IN_FLIGHT];
     ICommandList* m_ppCommandLists[MAX_FRAMES_IN_FLIGHT];
 
     ISemaphore* m_ppRenderingSemaphores[MAX_FRAMES_IN_FLIGHT];
-    IFence* m_pPrimaryBufferFence;
+    IFence* m_ppPrimaryBufferFences[MAX_FRAMES_IN_FLIGHT];
 };

--- a/src/Engine/UI/Panel.cpp
+++ b/src/Engine/UI/Panel.cpp
@@ -348,7 +348,7 @@ void UIHandler::renderTexturesOntoPanel(std::vector<TextureAttachment>& attachme
     m_pCommandList->bindVertexBuffer(0, m_pQuadVertices);
 
     for (AttachmentRenderResources& attachmentResources : renderResources) {
-        m_pCommandList->bindDescriptorSet(attachmentResources.pDescriptorSet, m_pPipelineLayout);
+        m_pCommandList->bindDescriptorSet(attachmentResources.pDescriptorSet, m_pPipelineLayout, 0u);
         m_pCommandList->draw(4u);
     }
 

--- a/src/Engine/Utils/ResourcePool.hpp
+++ b/src/Engine/Utils/ResourcePool.hpp
@@ -44,15 +44,7 @@ public:
 
     ~ResourcePool()
     {
-        if (m_Deleter) {
-            for (ResourceType* pResource : m_Resources) {
-                m_Deleter(pResource);
-            }
-        } else {
-            for (ResourceType* pResource : m_Resources) {
-                delete pResource;
-            }
-        }
+        clear();
     }
 
     void init(std::vector<ResourceType*> resources, std::function<void(ResourceType*)> m_Deleter = nullptr)
@@ -63,6 +55,21 @@ public:
         for (size_t freeIdx = 0u; freeIdx < m_FreeIndices.size(); freeIdx++) {
             m_FreeIndices[freeIdx] = freeIdx;
         }
+    }
+
+    void clear()
+    {
+        if (m_Deleter) {
+            for (ResourceType* pResource : m_Resources) {
+                m_Deleter(pResource);
+            }
+        } else {
+            for (ResourceType* pResource : m_Resources) {
+                delete pResource;
+            }
+        }
+
+        m_Resources.clear();
     }
 
     PooledResource<ResourceType> acquire()

--- a/src/Game/States/MainMenu.hpp
+++ b/src/Game/States/MainMenu.hpp
@@ -13,10 +13,10 @@ public:
     MainMenu(StateManager* pStateManager, ECSCore* pECS, Device* pDevice, InputHandler* pInputHandler);
     ~MainMenu();
 
-    void resume();
-    void pause();
+    void resume() override final;
+    void pause() override final;
 
-    void update(float dt);
+    void update(float dt) override final;
 
     Device* getDevice() { return m_pDevice; };
     InputHandler* getInputHandler() { return m_pInputHandler; }


### PR DESCRIPTION
Mesh is now rendering in vulkan, although not correctly at all. The application is also able to shut down without crashing when running with vulkan.

This MR contains the following fixes:
- Mesh_vs.glsl is now using `gl_Position`
- When popping the current game state, the state manager now reinstates the top entity page. This is irrelevant to the rendering fix, it was just found by accident
- When binding a descriptor set, the set's index in the shader now needs to be specified
- The `Device` base class now has a function to delete all graphics objects among its members. This ensures that all graphics objects are deleted before `DeviceVK::m_Device` is.
- Consolidated `DescriptorPool::allocateDescriptorSet` and `DescriptorPool::allocatedDescriptorSet`. Same treatment was given to the dealloc functions.
- Store one `Fence` per frame in `RenderingHandler` and implement a function for waiting for all frames currently enqueued for rendering. This is used when deleting resource amidst rendering.

And a bit more...