### PR TITLE
Flip y-axis in vulkan

### DIFF
--- a/assets/Engine/Shaders/Mesh_fs.glsl
+++ b/assets/Engine/Shaders/Mesh_fs.glsl
@@ -43,7 +43,7 @@ void main()
         vec3 toLight        = g_PerFrame.PointLights[lightIdx].Position - in_WorldPos;
         float distToLight   = length(toLight);
         toLight /= distToLight;
-        float cosAngle = min(dot(normal, toLight), 1.0);
+        float cosAngle = clamp(dot(normal, toLight), 0.0, 1.0);
 
         // Diffuse
         pointLight += cosAngle * g_PerFrame.PointLights[lightIdx].Light;
@@ -51,12 +51,12 @@ void main()
         // Specular
         vec3 toEye      = normalize(g_PerFrame.CameraPosition - in_WorldPos);
         vec3 halfwayVec = normalize(toLight + toEye);
-        pointLight += g_PerFrame.PointLights[lightIdx].Light * pow(min(dot(halfwayVec, in_Normal), 1.0), g_Material.Ks.r) * g_Material.Ks.g;
+        pointLight += g_PerFrame.PointLights[lightIdx].Light * pow(clamp(dot(halfwayVec, in_Normal), 0.0, 1.0), g_Material.Ks.r) * g_Material.Ks.g;
 
         // Attenuation
-        float attenuation = 1.0 - min(g_PerFrame.PointLights[lightIdx].RadiusRec * distToLight, 1.0);
+        float attenuation = 1.0 - clamp(g_PerFrame.PointLights[lightIdx].RadiusRec * distToLight, 0.0, 1.0);
         pointLight *= Kd * attenuation;
     }
 
-    out_Color = vec4(min(ambient + pointLight, vec3(1.0)), 1.0);
+    out_Color = vec4(clamp(ambient + pointLight, 0.0, 1.0), 1.0);
 }

--- a/assets/Engine/Shaders/Mesh_vs.glsl
+++ b/assets/Engine/Shaders/Mesh_vs.glsl
@@ -17,8 +17,8 @@ void main()
 {
     vec4 outPos         = vec4(in_Position, 1.0);
 
-    vec4 outWorldPos    = g_PerObject.World * outPos;
-    gl_Position         = g_PerObject.WVP * outPos;
-    out_Normal          = (g_PerObject.World * vec4(in_Normal, 0.0)).xyz;
+    vec4 outWorldPos    = outPos * g_PerObject.World;
+    gl_Position         = outPos * g_PerObject.WVP;
+    out_Normal          = (vec4(in_Normal, 0.0) * g_PerObject.World).xyz;
     out_TXCoords        = in_TXCoords;
 }

--- a/assets/Engine/Shaders/UI_vs.glsl
+++ b/assets/Engine/Shaders/UI_vs.glsl
@@ -20,6 +20,5 @@ void main()
     // Translate the quad by translating whilst converting positions in [0,1] to [-1,1]:
     // + position * 2.0 - 1:
     gl_Position     = vec4(in_Position * g_PerObject.Size * 2.0 + g_PerObject.Position * 2.0 - 1.0, 0.0, 1.0);
-    gl_Position.y   = -gl_Position.y;
     out_TXCoords    = in_TXCoords;
 }

--- a/src/Engine/IGame.cpp
+++ b/src/Engine/IGame.cpp
@@ -44,7 +44,7 @@ bool IGame::init()
     DescriptorCounts descriptorPoolSize;
     descriptorPoolSize.setAll(100u);
 
-    m_pDevice = Device::create(RENDERING_API::DIRECTX11, swapChainInfo, &m_Window);
+    m_pDevice = Device::create(RENDERING_API::VULKAN, swapChainInfo, &m_Window);
     if (!m_pDevice || !m_pDevice->init(descriptorPoolSize)) {
         return false;
     }

--- a/src/Engine/Rendering/APIAbstractions/Device.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Device.cpp
@@ -46,10 +46,10 @@ Device* Device::create(RENDERING_API API, const SwapchainInfo& swapchainInfo, co
 }
 
 Device::Device(QueueFamilyIndices queueFamilyIndices)
-    :m_QueueFamilyIndices(queueFamilyIndices),
-    m_pSwapchain(nullptr),
-    m_pShaderHandler(nullptr),
+    :m_pSwapchain(nullptr),
     m_FrameIndex(0u)
+    m_pShaderHandler(nullptr),
+    m_QueueFamilyIndices(queueFamilyIndices)
 {}
 
 Device::~Device()

--- a/src/Engine/Rendering/APIAbstractions/Device.hpp
+++ b/src/Engine/Rendering/APIAbstractions/Device.hpp
@@ -123,12 +123,12 @@ public:
     // waitIdle waits for the device to be idle
     virtual void waitIdle() = 0;
 
-    Swapchain* getSwapchain()                               { return m_pSwapchain; }
-    Texture* getBackbuffer(uint32_t frameIndex)             { return m_pSwapchain->getBackbuffer(frameIndex); }
-    Texture* getDepthStencil(uint32_t frameIndex)           { return m_pSwapchain->getDepthTexture(frameIndex); }
-    ShaderHandler* getShaderHandler()                       { return m_pShaderHandler; }
-    const QueueFamilyIndices& getQueueFamilyIndices() const { return m_QueueFamilyIndices; }
-    inline uint32_t& getFrameIndex()                        { return m_FrameIndex; }
+    inline Swapchain* getSwapchain()                                { return m_pSwapchain; }
+    inline uint32_t& getFrameIndex()                                { return m_FrameIndex; }
+    inline Texture* getBackbuffer(uint32_t frameIndex)              { return m_pSwapchain->getBackbuffer(frameIndex); }
+    inline Texture* getDepthStencil(uint32_t frameIndex)            { return m_pSwapchain->getDepthTexture(frameIndex); }
+    inline ShaderHandler* getShaderHandler()                        { return m_pShaderHandler; }
+    inline const QueueFamilyIndices& getQueueFamilyIndices() const  { return m_QueueFamilyIndices; }
 
 protected:
     friend DescriptorPoolHandler;

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/CommandListVK.cpp
@@ -98,7 +98,14 @@ void CommandListVK::bindIndexBuffer(IBuffer* pBuffer)
 
 void CommandListVK::bindViewport(const Viewport* pViewport)
 {
-    vkCmdSetViewport(m_CommandBuffer, 0u, 1u, (VkViewport*)pViewport);
+    VkViewport viewportVK = {};
+    std::memcpy(&viewportVK, pViewport, sizeof(VkViewport));
+
+    // Flip the y-axis to have it point up, and move the origin to the bottom
+    viewportVK.y      = viewportVK.height;
+    viewportVK.height = -viewportVK.height;
+
+    vkCmdSetViewport(m_CommandBuffer, 0u, 1u, &viewportVK);
 }
 
 void CommandListVK::bindScissor(const Rectangle2D& scissorRectangle)

--- a/src/Engine/Rendering/APIAbstractions/Vulkan/DeviceCreatorVK.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Vulkan/DeviceCreatorVK.cpp
@@ -10,7 +10,7 @@
 #include <vulkan/vulkan_win32.h>
 
 const std::vector<const char*> g_RequiredLayerNames         = { "VK_LAYER_KHRONOS_validation" };
-const std::vector<const char*> g_RequiredDeviceExtensions   = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
+const std::vector<const char*> g_RequiredDeviceExtensions   = { VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_MAINTENANCE1_EXTENSION_NAME };
 
 Device* DeviceCreatorVK::createDevice(const SwapchainInfo& swapChainInfo, const Window* pWindow)
 {

--- a/src/Game/States/GameSession.cpp
+++ b/src/Game/States/GameSession.cpp
@@ -138,7 +138,7 @@ void GameSession::createPlayer(TransformHandler* pTransformHandler, ComponentSub
     VelocityHandler* pVelocityHandler = reinterpret_cast<VelocityHandler*>(pComponentSubscriber->getComponentHandler(TID(VelocityHandler)));
     pVelocityHandler->createVelocityComponent(player);
 
-    VPHandler* pVPHandler = static_cast<VPHandler*>(pComponentSubscriber->getComponentHandler(TID(VPHandler)));
+    VPHandler* pVPHandler = reinterpret_cast<VPHandler*>(pComponentSubscriber->getComponentHandler(TID(VPHandler)));
 
     ViewMatrixInfo viewMatrixInfo = {};
     viewMatrixInfo.EyePosition      = DirectX::XMLoadFloat3(&camPosition);


### PR DESCRIPTION
The y-axis is flipped by enabling the `VK_KHR_MAINTENANCE1` extension and setting viewports' heights to be negative. Flipping the y-axis in vulkan means the clips-space coordinate system is now left handed.

- Rendering with mesh now works with vulkan. That means DirectX 11 and Vulkan are both working as intended!