### PR TITLE
Fix backfaces being lit

### DIFF
--- a/assets/Engine/Shaders/Mesh_fs.glsl
+++ b/assets/Engine/Shaders/Mesh_fs.glsl
@@ -11,21 +11,19 @@ layout (set = 2, binding = 3) uniform Material {
 
 struct PointLight {
     vec3 Position;
-    float RadiusRec;
     vec3 Light;
-    float Padding;
+    float RadiusRec;
 };
 
 layout (set = 0, binding = 0) uniform PerFrame {
     PointLight PointLights[MAX_LIGHTS];
     vec3 CameraPosition;
     uint NumLights;
-    vec4 Padding;
 } g_PerFrame;
 
-layout (location = 1) in vec3 in_Normal;
-layout (location = 2) in vec3 in_WorldPos;
-layout (location = 3) in vec2 in_TXCoords;
+layout (location = 0) in vec3 in_Normal;
+layout (location = 1) in vec3 in_WorldPos;
+layout (location = 2) in vec2 in_TXCoords;
 
 layout (location = 0) out vec4 out_Color;
 
@@ -35,7 +33,7 @@ void main()
 
     vec3 Kd = texture(u_DiffuseTexture, in_TXCoords).xyz;
 
-    vec3 ambient = Kd * 0.08;
+    vec3 ambient    = Kd * 0.08;
     vec3 pointLight = vec3(0.0);
 
     uint numLights = g_PerFrame.NumLights;
@@ -43,7 +41,10 @@ void main()
         vec3 toLight        = g_PerFrame.PointLights[lightIdx].Position - in_WorldPos;
         float distToLight   = length(toLight);
         toLight /= distToLight;
-        float cosAngle = clamp(dot(normal, toLight), 0.0, 1.0);
+        float cosAngle = dot(normal, toLight);
+        if (cosAngle < 0.0) {
+            continue;
+        }
 
         // Diffuse
         pointLight += cosAngle * g_PerFrame.PointLights[lightIdx].Light;
@@ -51,7 +52,7 @@ void main()
         // Specular
         vec3 toEye      = normalize(g_PerFrame.CameraPosition - in_WorldPos);
         vec3 halfwayVec = normalize(toLight + toEye);
-        pointLight += g_PerFrame.PointLights[lightIdx].Light * pow(clamp(dot(halfwayVec, in_Normal), 0.0, 1.0), g_Material.Ks.r) * g_Material.Ks.g;
+        pointLight += g_PerFrame.PointLights[lightIdx].Light * pow(clamp(dot(halfwayVec, normal), 0.0, 1.0), g_Material.Ks.r) * g_Material.Ks.g;
 
         // Attenuation
         float attenuation = 1.0 - clamp(g_PerFrame.PointLights[lightIdx].RadiusRec * distToLight, 0.0, 1.0);

--- a/assets/Engine/Shaders/Mesh_vs.glsl
+++ b/assets/Engine/Shaders/Mesh_vs.glsl
@@ -9,16 +9,16 @@ layout (location = 0) in vec3 in_Position;
 layout (location = 1) in vec3 in_Normal;
 layout (location = 2) in vec2 in_TXCoords;
 
-layout (location = 1) out vec3 out_Normal;
-layout (location = 2) out vec3 out_WorldPos;
-layout (location = 3) out vec2 out_TXCoords;
+layout (location = 0) out vec3 out_Normal;
+layout (location = 1) out vec3 out_WorldPos;
+layout (location = 2) out vec2 out_TXCoords;
 
 void main()
 {
-    vec4 outPos         = vec4(in_Position, 1.0);
+    vec4 inPos     = vec4(in_Position, 1.0);
 
-    vec4 outWorldPos    = outPos * g_PerObject.World;
-    gl_Position         = outPos * g_PerObject.WVP;
-    out_Normal          = (vec4(in_Normal, 0.0) * g_PerObject.World).xyz;
-    out_TXCoords        = in_TXCoords;
+    out_WorldPos    = (inPos * g_PerObject.World).xyz;
+    gl_Position     = inPos * g_PerObject.WVP;
+    out_Normal      = (vec4(in_Normal, 0.0) * g_PerObject.World).xyz;
+    out_TXCoords    = in_TXCoords;
 }

--- a/src/Engine/Rendering/APIAbstractions/Device.cpp
+++ b/src/Engine/Rendering/APIAbstractions/Device.cpp
@@ -47,7 +47,7 @@ Device* Device::create(RENDERING_API API, const SwapchainInfo& swapchainInfo, co
 
 Device::Device(QueueFamilyIndices queueFamilyIndices)
     :m_pSwapchain(nullptr),
-    m_FrameIndex(0u)
+    m_FrameIndex(0u),
     m_pShaderHandler(nullptr),
     m_QueueFamilyIndices(queueFamilyIndices)
 {}

--- a/src/Engine/Rendering/MeshRenderer.cpp
+++ b/src/Engine/Rendering/MeshRenderer.cpp
@@ -136,8 +136,8 @@ void MeshRenderer::updateBuffers()
 
         perFrame.PointLights[i] = {
             m_pTransformHandler->getPosition(pointLightEntity),
-            pointLight.RadiusReciprocal,
-            pointLight.Light
+            pointLight.Light,
+            pointLight.RadiusReciprocal
         };
     }
 
@@ -161,6 +161,7 @@ void MeshRenderer::updateBuffers()
         PerObjectMatrices matrices;
         matrices.World = m_pTransformHandler->getWorldMatrix(renderableID).worldMatrix;
         DirectX::XMStoreFloat4x4(&matrices.WVP, DirectX::XMMatrixTranspose(DirectX::XMLoadFloat4x4(&matrices.World) * camVP));
+        DirectX::XMStoreFloat4x4(&matrices.World, DirectX::XMMatrixTranspose(DirectX::XMLoadFloat4x4(&matrices.World)));
 
         pMappedMemory = nullptr;
         m_pDevice->map(modelRenderResources.pWVPBuffer, &pMappedMemory);

--- a/src/Engine/Rendering/MeshRenderer.hpp
+++ b/src/Engine/Rendering/MeshRenderer.hpp
@@ -44,11 +44,10 @@ public:
     inline Framebuffer* getFramebuffer(uint32_t frameIndex) { return m_ppFramebuffers[frameIndex]; }
 
 private:
-    struct PointLightBuffer {
-        DirectX::XMFLOAT3 Position;
+    struct alignas(16) PointLightBuffer {
+        alignas(16) DirectX::XMFLOAT3 Position;
+        alignas(16) DirectX::XMFLOAT3 Light;
         float RadiusReciprocal;
-        DirectX::XMFLOAT3 Light;
-        float Padding;
     };
 
     struct PerObjectMatrices {
@@ -57,9 +56,8 @@ private:
 
     struct PerFrameBuffer {
         PointLightBuffer PointLights[MAX_POINTLIGHTS];
-        DirectX::XMFLOAT3 CameraPosition;
+        alignas(16) DirectX::XMFLOAT3 CameraPosition;
         uint32_t NumLights;
-        DirectX::XMFLOAT4 Padding;
     };
 
 private:


### PR DESCRIPTION
The world matrix in the WVP buffer wasn't being updated, meaning each object in the scene was positioned at the same place. This meant each cube got the same world position, which had a noticeable effect on the lighting.

Also:
- Tweaked the buffer structs to follow alignment rules of the graphics APIs using alignas instead of padding variables
- Mesh_fs no longer lights up backfaces