### PR TITLE
Cppcheck project

### DIFF
--- a/.cppcheck/lint.cppcheck
+++ b/.cppcheck/lint.cppcheck
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="1">
+    <builddir>lint-cppcheck-build-dir</builddir>
+    <platform>Unspecified</platform>
+    <importproject>../GameProject.vcxproj</importproject>
+    <analyze-all-vs-configs>true</analyze-all-vs-configs>
+    <check-headers>true</check-headers>
+    <check-unused-templates>false</check-unused-templates>
+    <max-ctu-depth>10</max-ctu-depth>
+    <vs-configurations>
+        <config>Debug</config>
+        <config>Release</config>
+    </vs-configurations>
+    <exclude>
+        <path name="../vendor/"/>
+    </exclude>
+    <suppressions>
+        <suppression>unusedFunction</suppression>
+    </suppressions>
+</project>

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,8 @@ log.txt
 
 !libs/*
 
+# SPIR-V shaders
 *.spv
+
+# cppcheck files
+.cppcheck/lint-cppcheck-build-dir/

--- a/GameProject.sln
+++ b/GameProject.sln
@@ -8,19 +8,13 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E4DC0D9E-7A35-44C8-BBBC-1D83AD761CF2}.Debug|x64.ActiveCfg = Debug|x64
 		{E4DC0D9E-7A35-44C8-BBBC-1D83AD761CF2}.Debug|x64.Build.0 = Debug|x64
-		{E4DC0D9E-7A35-44C8-BBBC-1D83AD761CF2}.Debug|x86.ActiveCfg = Debug|Win32
-		{E4DC0D9E-7A35-44C8-BBBC-1D83AD761CF2}.Debug|x86.Build.0 = Debug|Win32
 		{E4DC0D9E-7A35-44C8-BBBC-1D83AD761CF2}.Release|x64.ActiveCfg = Release|x64
 		{E4DC0D9E-7A35-44C8-BBBC-1D83AD761CF2}.Release|x64.Build.0 = Release|x64
-		{E4DC0D9E-7A35-44C8-BBBC-1D83AD761CF2}.Release|x86.ActiveCfg = Release|Win32
-		{E4DC0D9E-7A35-44C8-BBBC-1D83AD761CF2}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GameProject.vcxproj
+++ b/GameProject.vcxproj
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
@@ -25,19 +17,6 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -56,12 +35,6 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -70,14 +43,6 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup />
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
-    </ClCompile>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -93,20 +58,6 @@
     <Link>
       <AdditionalLibraryDirectories>$(ProjectDir)libs\Common;$(ProjectDir)libs\Debug\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>assimp-vc140-mt.lib;vulkan-1.lib;freetype-d.lib;d3d11.lib;runtimeobject.lib;D3DCompiler.lib;fmodL_vc.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
-    </ClCompile>
-    <Link>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 ![Välfärden](https://github.com/TheoBerlin/SoloGame/workflows/V%C3%A4lf%C3%A4rden/badge.svg)
 
 ## What is this project?
-In this repository is an engine and a game, both being made from scratch using C++, DirectX and Vulkan. Both game and engine are far from being finalized. This is a project I started for two purposes; to learn and to have something to display to employers.
+In this repository is an engine being made from scratch using C++. Graphics rendering is performed by either DirectX or Vulkan. This is a project I started working on for two purposes; to learn and to have something to display to employers.
+
+## Contributing
+Cppcheck is a C++ linter used in the project's workflow. For a pull request to be accepted, it needs to pass the linter checks. Thus, locally installing cppcheck is recommended.
+
+#### Setting up cppcheck
+1. Download and install cppcheck from http://cppcheck.sourceforge.net/
+2. Open the cppcheck GUI
+3. Load the cppcheck project file .cppcheck/lint.cppcheck
 
 ## Highlights in the code
-Probably the best part of the code is the implementation of the Entity Component System (ECS) architecture. This resides in the
+### ECS
+The engine uses an Entity Component System (ECS) architecture for storing game object data and performing logic. ECS resides in the
 [Engine/ECS folder](https://github.com/TheoBerlin/SoloGame/tree/master/src/Engine/ECS).
 It's very much inspired by
 various discussions and videos, such as [this talk at GDC](https://www.youtube.com/watch?v=0_Byw9UMn9g).
@@ -23,6 +32,3 @@ written to by another system.
 
 The updating of systems is done in
 [Engine/ECS/SystemUpdater.cpp](https://github.com/TheoBerlin/SoloGame/blob/master/src/Engine/ECS/SystemUpdater.cpp).
-
-## What will the final game look like?
-I'm trying to make something very small, to make sure the game is finished in time for my graduation in 2021.


### PR DESCRIPTION
The cppcheck project can be used to ensure the same cppcheck settings are used by all contributors.

Also updated the README with info on linting with cppcheck, and removed 32-bit build configurations.